### PR TITLE
Fix default HiGHS backend parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 
 # Changelog
 
+## [0.3.1] – 2025-05-21
+### Fixed
+- Corrected default OR-Tools backend name to `"HIGHS"` in `ortools_solver.py`.
+
 ## [0.3.0] – 2025-05-17
 ### Added
 - **Open‑source solver scaffold** (`backend/solver/`) introducing:

--- a/backend/solver/ortools_solver.py
+++ b/backend/solver/ortools_solver.py
@@ -13,7 +13,7 @@ from .base import ILPSolver, SupportsStability
 
 
 class OrtoolsSolver(ILPSolver):
-    def __init__(self, backend: str = "HIGHs"):
+    def __init__(self, backend: str = "HIGHS"):
         # Keep a reference for future model builds
         self.backend = backend
         # Quick self-test: create a dummy solver instance


### PR DESCRIPTION
## Summary
- tweak default solver backend name in `OrtoolsSolver`
- document the backend fix in CHANGELOG

## Testing
- `poetry run pytest -q` *(fails: Command not found)*