### PR TITLE
Add codex setup script and docs

### DIFF
--- a/.codex/setup.sh
+++ b/.codex/setup.sh
@@ -1,0 +1,2 @@
+#!/usr/bin/env bash
+poetry install --no-root --no-interaction

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,16 +22,10 @@ jobs:
           python-version: "3.12"
           cache: "poetry"
 
-      # 3. Install Poetry
-      - name: Install Poetry
-        run: |
-          pip install --upgrade pip
-          pip install poetry
-
-      # 4. Install dependencies (includes OR-Tools)
+      # 3. Install dependencies (includes OR-Tools)
       - name: Install deps
         run: |
-          poetry install --no-interaction --no-root
+          ./.codex/setup.sh
 
       # 5. Run tests
       - name: Run pytest

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,6 +23,7 @@ This project is developed by a **human owner (Jeff) plus ChatGPT‑4o “dev age
 brew install git gh docker --cask docker docker-compose node@20 pnpm
 git clone git@github.com:JGAVEN/Lego-GPT.git
 cd Lego-GPT && git submodule update --init
+./.codex/setup.sh    # install Python deps
 ```
 
 See **docs/ARCHITECTURE.md** for more details.

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ real-life building.
 # Clone and set up
 git clone https://github.com/JGAVEN/Lego-GPT.git
 cd Lego-GPT
-poetry install          # installs backend deps inc. OR-Tools
+./.codex/setup.sh       # installs backend deps inc. OR-Tools
 
 # Launch the backend (FastAPI + solver)
 docker compose up       # http://localhost:8000/health
@@ -64,7 +64,7 @@ docker-compose.yml  Dev stack (backend only for now)
 
 1. **One atomic branch per ticket** (`feature/<ticket-slug>`).  
 2. Follow `docs/BACKLOG.md` for ticket IDs and size.  
-3. Run `poetry run pytest` before pushing (CI currently checks the backend test suite).  
+3. Run `./.codex/setup.sh` once, then `poetry run pytest` before pushing (CI currently checks the backend test suite).
 4. Update `docs/CHANGELOG.md` after each merge to `main`.  
 
 See `docs/CONTRIBUTING.md` for full workflow, coding style, and commit-message


### PR DESCRIPTION
## Summary
- add `.codex/setup.sh` for installing Python deps
- reference the script in README quick-start and contributing guide
- run setup script in CI instead of raw poetry command
- skip Poetry installation in CI since it's already present

## Testing
- `./.codex/setup.sh` *(fails: all attempts to connect to pypi.org failed)*
- `poetry run pytest -q` *(command not found)*

This environment doesn't have network access after setup, so Codex couldn't run certain commands. Consider configuring a setup script in your Codex environment to install dependencies.