### PR TITLE
Add Codex setup script

### DIFF
--- a/.codex/setup.sh
+++ b/.codex/setup.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+set -euo pipefail
+
+# Update submodules
+if [ -f .gitmodules ]; then
+  git submodule update --init --recursive
+fi
+
+# Install Python dependencies for the backend
+poetry install --no-interaction --no-root
+
+# Install frontend dependencies
+if [ -d "frontend" ]; then
+  cd frontend
+  pnpm install
+  cd ..
+fi


### PR DESCRIPTION
## Summary
- add `.codex/setup.sh` for offline setup

## Testing
- `bash .codex/setup.sh` *(fails: cannot install dependencies offline)*
- `poetry run pytest -q` *(fails: pytest not installed)*