### PR TITLE
Fix linting issues

### DIFF
--- a/backend/server.py
+++ b/backend/server.py
@@ -1,7 +1,6 @@
 """Tiny HTTP server exposing the Lego GPT API offline."""
 import json
 from http.server import HTTPServer, BaseHTTPRequestHandler
-from pathlib import Path
 from backend.api import health, generate_lego_model, STATIC_ROOT
 
 

--- a/backend/solver/base.py
+++ b/backend/solver/base.py
@@ -6,25 +6,24 @@ that implement `ILPSolver.solve(bricks) -> bricks`.
 """
 from __future__ import annotations
 
+import sys
+from pathlib import Path
+from abc import ABC, abstractmethod
+from typing import List, Protocol, runtime_checkable
+
 # ------------------------------------------------------------------
 # Ensure the vendored LegoGPT library is importable.
 # Repo layout: repo_root/vendor/legogpt/…
 # We insert the vendor directory so `import legogpt` works
 # from anywhere (tests, backend, worker containers, etc.).
 # ------------------------------------------------------------------
-import sys
-from pathlib import Path
-
 vendor_root = Path(__file__).resolve().parents[2] / "vendor"
 if vendor_root.exists() and str(vendor_root) not in sys.path:
     sys.path.insert(0, str(vendor_root))
 # ------------------------------------------------------------------
 
-from abc import ABC, abstractmethod
-from typing import List, Protocol, runtime_checkable
-
 # Re-use Brick dataclass from the CMU sub-module
-from legogpt.data import LegoBrick
+from legogpt.data import LegoBrick  # noqa: E402
 
 
 @runtime_checkable

--- a/backend/tests/test_generate.py
+++ b/backend/tests/test_generate.py
@@ -1,8 +1,8 @@
+import os
+import sys
 import unittest
 from pathlib import Path
-import sys
-import os
-from unittest.mock import patch, MagicMock
+from unittest.mock import MagicMock, patch
 
 # Ensure project root is importable
 project_root = Path(__file__).resolve().parents[2]
@@ -12,7 +12,7 @@ for p in (project_root, vendor_root):
         sys.path.insert(0, str(p))
 os.environ["PYTHONPATH"] = str(project_root)
 
-from backend.api import generate_lego_model
+from backend.api import generate_lego_model  # noqa: E402
 
 
 class GenerateTests(unittest.TestCase):


### PR DESCRIPTION
## Summary
- clean up ruff errors in backend modules

## Testing
- `ruff check . --exclude vendor`
- `pytest -q backend/tests/test_generate.py` *(fails: pytest not installed)*