### PR TITLE
Align API contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,30 @@ docker-compose.yml  Dev stack (backend only for now)
 
 &nbsp;
 
-## 5. Contributing
+## 5. API Contract
+
+`POST /generate` accepts a JSON body:
+
+```json
+{ "prompt": "text description", "seed": 42 }
+```
+
+It returns direct links to the generated assets:
+
+```json
+{
+  "png_url": "/static/{uuid}/preview.png",
+  "ldr_url": "/static/{uuid}/model.ldr",  // may be null
+  "brick_counts": { "Brick 2 x 4": 12 }
+}
+```
+
+The `png_url` can be shown directly in an `<img>` tag. The optional
+`ldr_url` is for future Three.js viewing.
+
+&nbsp;
+
+## 6. Contributing
 
 1. **One atomic branch per ticket** (`feature/<ticket-slug>`).  
 2. Follow `docs/BACKLOG.md` for ticket IDs and size.  
@@ -65,7 +88,7 @@ conventions.
 
 &nbsp;
 
-## 6. Licence
+## 7. Licence
 
 | Component | Licence |
 |-----------|---------|

--- a/docs/PROJECT_BACKLOG.md
+++ b/docs/PROJECT_BACKLOG.md
@@ -13,7 +13,7 @@
 | B-08 | **C** | AR Quick-Look export                 | **Open** | glTF pipeline |
 | B-09 | **C** | Brick inventory filter               | **Open** | Fine-tune on owned parts |
 | B-10 | **M** | Add MIT licence text                 | **Done** | Root and vendor licence files added |
-| B-11 | **M** | Align API contract                   | **Open** | Front-end expects `{png, ldr}`, backend returns `{png_url, ldr_url, brick_counts}` |
+| B-11 | **M** | Align API contract                   | **Done** | Unified on `{png_url, ldr_url, brick_counts}` |
 |------|-----|---------------------------------------|--------|-------|
 | S-10 | **M** | Introduce `ILPSolver` interface & refactor | **Done** | Branch `feature/solver-refactor` |
 | S-11 | **M** | Implement OR-Tools MIP constraints   | **WIP** | Connectivity, gravity, overhang; solver shim returns dummy score |
@@ -24,4 +24,4 @@
 * **Pri** – MoSCoW priority (**M**ust, **S**hould, **C**ould, **W**on’t-Have-Now).
 * **Status** – Open / WIP / Blocked / Done.
 
-_Last updated 2025-05-22_
+_Last updated 2025-05-23_

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -20,14 +20,7 @@ export default function App() {
         seed: seed ? Number(seed) : null,
       });
 
-      // Prefer the static URL if present; fall back to base-64
-      if ("png_url" in res && res.png_url) {
-        setImgSrc(res.png_url);
-      } else if ("png" in res && res.png) {
-        setImgSrc(`data:image/png;base64,${res.png}`);
-      } else {
-        throw new Error("Backend response lacked png data");
-      }
+      setImgSrc(res.png_url);
     } catch (err: any) {
       setError(err.message ?? "Unknown error");
     } finally {

--- a/frontend/src/api/lego.ts
+++ b/frontend/src/api/lego.ts
@@ -4,8 +4,9 @@ export interface GenerateRequest {
 }
 
 export interface GenerateResponse {
-  png: string;          // base-64 PNG
-  ldr?: string;         // reserved for future use
+  png_url: string;
+  ldr_url: string | null;
+  brick_counts: Record<string, number>;
 }
 
 export async function generateLego(


### PR DESCRIPTION
## Summary
- standardise `/generate` to return `{png_url, ldr_url, brick_counts}`
- update front-end API types and logic
- document the contract in README
- close backlog item B‑11

## Testing
- `python -m unittest discover -v`