### PR TITLE
Implement RQ-based worker

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,13 @@ real-life building.
 git clone https://github.com/JGAVEN/Lego-GPT.git
 cd Lego-GPT
 
-# Launch the backend (simple HTTP server)
+# Start Redis (local or Docker)
+# docker run -p 6379:6379 -d redis:7
+
+# Launch the RQ worker in one terminal
+python backend/worker.py
+
+# Launch the API server in another
 python backend/server.py    # http://localhost:8000/health
 ```
 

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -2,3 +2,7 @@
 name = "lego-gpt-backend"
 version = "0.1.0"
 requires-python = ">=3.11"
+dependencies = [
+    "redis>=5",
+    "rq>=1.16",
+]

--- a/backend/tests/test_queue.py
+++ b/backend/tests/test_queue.py
@@ -1,0 +1,43 @@
+import os
+import sys
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+project_root = Path(__file__).resolve().parents[2]
+vendor_root = project_root / "vendor"
+for p in (project_root, vendor_root):
+    if str(p) not in sys.path:
+        sys.path.insert(0, str(p))
+os.environ["PYTHONPATH"] = str(project_root)
+
+try:
+    import fakeredis  # type: ignore
+except Exception:  # pragma: no cover - optional dep may be missing
+    fakeredis = None
+
+from rq import Queue, SimpleWorker
+import backend.worker as worker
+
+
+class QueueTests(unittest.TestCase):
+    def test_generate_job_runs(self):
+        if fakeredis is None:
+            self.skipTest("fakeredis not installed")
+        redis_conn = fakeredis.FakeRedis()
+        q = Queue(worker.QUEUE_NAME, connection=redis_conn)
+        with patch("backend.worker.generate_lego_model") as mock_gen:
+            mock_gen.return_value = {
+                "png_url": "/static/x/preview.png",
+                "ldr_url": None,
+                "brick_counts": {},
+            }
+            job = q.enqueue(worker.generate_job, "cube", 1)
+            SimpleWorker([q], connection=redis_conn).work(burst=True)
+            self.assertTrue(job.is_finished)
+            self.assertEqual(job.result["png_url"], "/static/x/preview.png")
+            mock_gen.assert_called_once()
+
+
+if __name__ == "__main__":  # pragma: no cover
+    unittest.main()

--- a/backend/worker.py
+++ b/backend/worker.py
@@ -1,0 +1,23 @@
+"""RQ worker for asynchronous generation jobs."""
+from redis import Redis
+from rq import Worker, Queue, Connection
+from backend.api import generate_lego_model
+
+QUEUE_NAME = "legogpt"
+
+
+def generate_job(prompt: str, seed: int | None = 42) -> dict:
+    """Background job that runs the model and returns file URLs."""
+    return generate_lego_model(prompt, seed)
+
+
+def run_worker(redis_url: str = "redis://localhost:6379/0") -> None:
+    """Entry point to start an RQ worker."""
+    conn = Redis.from_url(redis_url)
+    with Connection(conn):
+        worker = Worker([QUEUE_NAME])
+        worker.work()
+
+
+if __name__ == "__main__":  # pragma: no cover
+    run_worker()


### PR DESCRIPTION
## Summary
- add Redis RQ worker module
- enqueue generation jobs in HTTP API server
- document worker startup in README and ARCHITECTURE
- add a queue unit test
- specify rq/redis deps for backend

## Testing
- `python -m unittest discover backend/tests -v` *(fails: ModuleNotFoundError: No module named 'rq')*