### PR TITLE
Add Three.js LDraw viewer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 
 # Changelog
 
+## [0.3.6] – 2025-05-23
+### Added
+- Three.js LDraw viewer component loads `.ldr` output when available.
+
 ## [0.3.5] – 2025-05-23
 ### Added
 - Unit tests for JWT encode/decode helpers.

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Lego GPT pairs the CMU **LegoGPT** Llama-3 1B model with a small **HTTP** server
 and a **React + Three.js** progressive-web-app (PWA).
 The model converts natural-language prompts into **LDraw** brick assemblies,
 renders a PNG preview, and serves the `.ldr` file for 3-D manipulation or
-real-life building.
+real-life building via a built-in Three.js viewer.
 
 &nbsp;
 
@@ -22,6 +22,7 @@ real-life building.
 | 🩹 **Solver shim** monkey-patches the CMU call-site (`stability_score`). | Upstream sub-module remains untouched. |
 | 🔐 **JWT auth + rate limit** on `/generate` | Prevents abuse; set `JWT_SECRET` and `RATE_LIMIT` |
 | 🧩 **Connectivity filter** in solver | Removes brick clusters not connected to the ground |
+| 🖼️ **Three.js LDraw viewer** | Interactive 3-D view if `.ldr` output is available |
 
 &nbsp;
 
@@ -91,8 +92,8 @@ Poll the job via `GET /generate/{job_id}` to receive the asset links:
 }
 ```
 
-The `png_url` can be shown directly in an `<img>` tag. The optional
-`ldr_url` is for future Three.js viewing.
+The `png_url` can be shown directly in an `<img>` tag. If `ldr_url` is present,
+pass it to the `LDrawViewer` React component for interactive viewing.
 
 Default rate limit is `5` generate requests per token per minute (configurable via `RATE_LIMIT`).
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -41,7 +41,7 @@ clusters not connected to the ground.
 
 | Layer      | Responsibility                                                                                 | Tech / Notes |
 |------------|-------------------------------------------------------------------------------------------------|--------------|
-| **Front-end** | Prompt form, spinner, preview image, 3-D viewer, offline PWA shell                            | React 18, Vite, Three.js (`LDrawLoader`) |
+| **Front-end** | Prompt form, spinner, preview image, 3-D viewer, offline PWA shell                            | React 18, Vite, Three.js (`LDrawLoader` from CDN) |
 | **API**       | Auth, rate-limit, enqueue job, expose static file links                                       | Python http.server stub |
 | **Worker**    | `backend/worker.py` runs `rq` jobs, lazy-loads LegoGPT, routes bricks → solver, saves PNG + LDR | Python 3.12, CUDA 12.2, HF `transformers` |
 | **Solver**    | Verify physical stability via MIP (connectivity, gravity, overhang)                           | OR-Tools / HiGHS (default), Gurobi optional |
@@ -57,6 +57,7 @@ clusters not connected to the ground.
 4. Worker writes `preview.png` + `model.ldr` to `/static/{uuid}/`.
 5. When finished, a GET on `/generate/{job_id}` returns `{png_url, ldr_url, brick_counts}`.
 6. Client shows PNG immediately; Three.js lazily loads LDR → interactive viewer.
+   The `LDrawLoader` module is fetched from a CDN at runtime.
 
 ---
 

--- a/docs/PROJECT_BACKLOG.md
+++ b/docs/PROJECT_BACKLOG.md
@@ -7,7 +7,7 @@
 | B-02 | **M** | React PWA scaffold                   | **Done** | Vite + Tailwind, SW cache |
 | B-03 | **M** | `/generate` endpoint                 | **Done** | Async job queue, return URLs |
 | B-04 | **M** | React API hook + PNG preview         | **Done** | Front-end calls `/generate`, shows preview |
-| B-05 | **S** | Three.js LDraw viewer                | **Blocked** | Depends on B-04 |
+| B-05 | **S** | Three.js LDraw viewer                | **Done** | Loads `.ldr` via dynamic import |
 | B-06 | **S** | JWT auth & rate-limit                | **Done** | Simple HMAC tokens + per-minute limit |
 | B-07 | **S** | GitHub Actions CI                    | **Done** | unittest + build images |
 | B-08 | **C** | AR Quick-Look export                 | **Open** | glTF pipeline |

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,5 +1,6 @@
 import { useState, FormEvent } from "react";
 import useGenerate from "./api/useGenerate";
+import LDrawViewer from "./LDrawViewer";
 
 export default function App() {
   const [prompt, setPrompt] = useState("");
@@ -56,11 +57,18 @@ export default function App() {
       {error && <p className="mt-4 text-red-600">{error}</p>}
 
       {data?.png_url && !loading && (
-        <img
-          src={data.png_url}
-          alt="Lego preview"
-          className="mt-6 w-full h-auto border"
-        />
+        <>
+          <img
+            src={data.png_url}
+            alt="Lego preview"
+            className="mt-6 w-full h-auto border"
+          />
+          {data.ldr_url && (
+            <div className="mt-6">
+              <LDrawViewer url={data.ldr_url} />
+            </div>
+          )}
+        </>
       )}
     </main>
   );

--- a/frontend/src/LDrawViewer.tsx
+++ b/frontend/src/LDrawViewer.tsx
@@ -1,0 +1,67 @@
+import { useRef, useEffect } from "react";
+
+interface Props {
+  url: string;
+}
+
+export default function LDrawViewer({ url }: Props) {
+  const mountRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!mountRef.current) return;
+
+    let renderer: any;
+    let animationId: number;
+
+    async function init() {
+      const THREE = await import(
+        /* @vite-ignore */
+        "https://unpkg.com/three@0.160.0/build/three.module.js?module"
+      );
+      const { LDrawLoader } = await import(
+        /* @vite-ignore */
+        "https://unpkg.com/three@0.160.0/examples/jsm/loaders/LDrawLoader.js?module"
+      );
+
+      const scene = new THREE.Scene();
+      const camera = new THREE.PerspectiveCamera(
+        45,
+        mountRef.current!.clientWidth / 400,
+        1,
+        2000
+      );
+      camera.position.set(200, 200, 200);
+      camera.lookAt(0, 0, 0);
+
+      renderer = new THREE.WebGLRenderer({ antialias: true });
+      renderer.setSize(mountRef.current!.clientWidth, 400);
+      mountRef.current!.appendChild(renderer.domElement);
+
+      const loader = new LDrawLoader();
+      loader.load(url, (group: any) => {
+        scene.add(group);
+        animate();
+      });
+
+      function animate() {
+        animationId = requestAnimationFrame(animate);
+        renderer.render(scene, camera);
+      }
+    }
+
+    init();
+    return () => {
+      if (renderer) {
+        renderer.dispose();
+      }
+      if (animationId) {
+        cancelAnimationFrame(animationId);
+      }
+      if (mountRef.current && renderer) {
+        mountRef.current.removeChild(renderer.domElement);
+      }
+    };
+  }, [url]);
+
+  return <div ref={mountRef} style={{ width: "100%", height: 400 }} />;
+}


### PR DESCRIPTION
## Summary
- implement `LDrawViewer` React component using CDN modules
- show 3‑D view in `App.tsx` when `ldr_url` is available
- document viewer in README, ARCHITECTURE and PROJECT_BACKLOG
- bump changelog to 0.3.6

## Testing
- `python -m unittest discover -v`