### PR TITLE
Fix offline pnpm install

### DIFF
--- a/.codex/setup.sh
+++ b/.codex/setup.sh
@@ -8,3 +8,6 @@ fi
 
 # Install OR-Tools before network access is disabled
 python -m pip install --no-cache-dir ortools
+
+# Install front-end packages while network access is available
+pnpm install --dir frontend

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 
 # Changelog
 
+## [0.3.7] – 2025-05-23
+### Added
+- Setup script now installs front-end packages via PNPM before network access is disabled.
+### Changed
+- Docs updated to note automatic PNPM install and offline setup.
+
 ## [0.3.6] – 2025-05-23
 ### Added
 - Three.js LDraw viewer component loads `.ldr` output when available.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,7 +23,7 @@ This project is developed by a **human owner (Jeff) plus ChatGPT‑4o “dev age
 brew install git gh docker --cask docker docker-compose node@20 pnpm
 git clone git@github.com:JGAVEN/Lego-GPT.git
 cd Lego-GPT && git submodule update --init
-pnpm install --dir frontend
+pnpm install --dir frontend  # run automatically in the dev container
 python -m pip install --editable ./backend
 ```
 

--- a/README.md
+++ b/README.md
@@ -103,8 +103,8 @@ Default rate limit is `5` generate requests per token per minute (configurable v
 
 1. **One atomic branch per ticket** (`feature/<ticket-slug>`).
 2. Follow `docs/PROJECT_BACKLOG.md` for ticket IDs and size.
-3. Install front-end dependencies with `pnpm install` (run inside `frontend/`)
-   before running `npm run lint`.
+3. Front-end dependencies are installed automatically during setup
+   (`pnpm install --dir frontend`). Run `npm run lint` after editing UI code.
 4. Run `python -m unittest discover -v` before pushing. The test suite uses
    Python's built-in `unittest` module—no need for `pytest`.
 5. Update `docs/CHANGELOG.md` after each merge to `main`.

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -59,8 +59,8 @@ Install dependencies once and start Vite:
 
 ```bash
 cd frontend
-npm install
-npm run dev
+pnpm install        # already run in the dev container's setup
+pnpm run dev
 ```
 
 The app will be available at <http://localhost:5173> by default.


### PR DESCRIPTION
## Summary
- install front-end packages during setup
- document that pnpm install now runs automatically
- update local setup instructions
- note change in changelog

## Testing
- `python -m unittest discover -v`
