### PR TITLE
feat: per-request inventory filter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 * **Photo‑based brick inventory detection** feature (YOLOv8 detector, `/detect_inventory` API, front‑end scan workflow).
 * `/detect_inventory` endpoint implementation with stub worker and tests.
 * Declared `ortools` dependency in `backend/pyproject.toml`.
+* `inventory_filter` payload option for `/generate` to limit bricks per request.
 
 ### Changed
 * Updated architecture and backlog documentation.

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ real-life building via a built-in Three.js viewer.
 | 🧩 **Connectivity filter** in solver | Removes brick clusters not connected to the ground |
 | 🖼️ **Three.js LDraw viewer** | Interactive 3-D view if `.ldr` output is available |
 | 🌐 **AR Quick-Look export** | `.gltf` file for iOS AR viewer |
-| 📦 **Inventory filter** | Limits brick counts using `BRICK_INVENTORY` JSON |
+| 📦 **Inventory filter** | Limits brick counts using `BRICK_INVENTORY` JSON or per-request `inventory_filter` |
 | 🆕 **Photo‑based brick inventory detection** – YOLOv8 detector + `/detect_inventory` API | Scan your loose bricks and generate builds you can actually build |
 
 &nbsp;
@@ -77,7 +77,11 @@ docker-compose.yml  Dev stack (backend only for now)
 `POST /generate` requires an `Authorization: Bearer <token>` header and accepts a JSON body:
 
 ```json
-{ "prompt": "text description", "seed": 42 }
+{
+  "prompt": "text description",
+  "seed": 42,
+  "inventory_filter": { "3001.DAT": 2 }  // optional
+}
 ```
 
 It returns a job handle:

--- a/backend/api.py
+++ b/backend/api.py
@@ -10,9 +10,13 @@ def health() -> dict:
     return {"ok": True}
 
 
-def generate_lego_model(prompt: str, seed: int = 42) -> dict:
+def generate_lego_model(
+    prompt: str, seed: int = 42, inventory_filter: dict[str, int] | None = None
+) -> dict:
     """Run the model and return URLs for the generated preview and models."""
-    png_path, ldr_path, gltf_path, brick_counts = generate(prompt, seed)
+    png_path, ldr_path, gltf_path, brick_counts = generate(
+        prompt, seed, inventory_filter
+    )
     rel_png = Path(png_path).resolve().relative_to(STATIC_ROOT.parent)
     png_url = f"/static/{rel_png.parent.name}/preview.png"
     ldr_url = None

--- a/backend/inference.py
+++ b/backend/inference.py
@@ -35,7 +35,7 @@ def load_model():
 # --------------------------------------------------------------------------- #
 #                               Entry point                                   #
 # --------------------------------------------------------------------------- #
-def generate(prompt: str, seed: int | None = None):
+def generate(prompt: str, seed: int | None = None, inventory_filter: dict[str, int] | None = None):
     """
     Generate a new LEGO structure preview.
 
@@ -45,6 +45,8 @@ def generate(prompt: str, seed: int | None = None):
         Natural-language prompt from the user.
     seed : int | None
         Optional RNG seed for reproducibility.
+    inventory_filter : dict[str, int] | None
+        Optional inventory map to limit brick counts.
 
     Returns
     -------
@@ -76,5 +78,5 @@ def generate(prompt: str, seed: int | None = None):
         gltf_path_str = None
 
     counts = result.get("brick_counts", {})
-    counts = filter_counts(counts)
+    counts = filter_counts(counts, inventory_filter)
     return str(png_path), ldr_path_str, gltf_path_str, counts

--- a/backend/inventory.py
+++ b/backend/inventory.py
@@ -34,9 +34,18 @@ def get_inventory() -> Dict[str, int]:
     return _INVENTORY
 
 
-def filter_counts(counts: Dict[str, int]) -> Dict[str, int]:
-    """Trim brick counts to the available inventory."""
-    inv = get_inventory()
+def filter_counts(counts: Dict[str, int], inventory: Dict[str, int] | None = None) -> Dict[str, int]:
+    """Trim brick counts to the available inventory.
+
+    Parameters
+    ----------
+    counts : Dict[str, int]
+        Brick counts returned by the model.
+    inventory : Dict[str, int] | None
+        Optional inventory map to use instead of the global
+        ``BRICK_INVENTORY``.
+    """
+    inv = inventory if inventory is not None else get_inventory()
     if not inv:
         return counts
     filtered: Dict[str, int] = {}

--- a/backend/server.py
+++ b/backend/server.py
@@ -133,7 +133,11 @@ class Handler(BaseHTTPRequestHandler):
                 return
             prompt = payload.get("prompt", "")
             seed = payload.get("seed", 42)
-            job_obj = queue.enqueue(generate_job, prompt, seed)
+            inventory = payload.get("inventory_filter")
+            if inventory is not None and not isinstance(inventory, dict):
+                self.send_error(400, "Invalid inventory_filter")
+                return
+            job_obj = queue.enqueue(generate_job, prompt, seed, inventory)
             self._send_json({"job_id": job_obj.id})
             return
         if self.path == "/detect_inventory":

--- a/backend/tests/test_generate.py
+++ b/backend/tests/test_generate.py
@@ -16,24 +16,23 @@ from backend.api import generate_lego_model  # noqa: E402
 
 
 class GenerateTests(unittest.TestCase):
-    @patch("backend.inference.ldr_to_gltf")
-    @patch("backend.inference.load_model")
-    def test_generate_endpoint(self, mock_load_model, mock_gltf):
-        mock_model = MagicMock()
-        mock_model.generate.return_value = {
-            "png": b"fake_png_data",
-            "ldr": "0 FAKE_BRICK 0 0 0",
-            "brick_counts": {"Brick": 1}
-        }
-        mock_load_model.return_value = mock_model
+    @patch("backend.api.generate")
+    def test_generate_endpoint(self, mock_generate):
+        mock_generate.return_value = (
+            "backend/static/x/preview.png",
+            "backend/static/x/model.ldr",
+            "backend/static/x/model.gltf",
+            {"Brick": 1},
+        )
 
-        data = generate_lego_model("blue cube", 42)
+        inv = {"Brick": 1}
+        data = generate_lego_model("blue cube", 42, inv)
         self.assertIn("png_url", data)
         self.assertTrue(data["png_url"].endswith("preview.png"))
         self.assertIn("ldr_url", data)
         self.assertTrue(data["ldr_url"].endswith("model.ldr"))
         self.assertTrue(data["gltf_url"].endswith("model.gltf"))
-        mock_gltf.assert_called_once()
+        mock_generate.assert_called_once_with("blue cube", 42, inv)
         self.assertIsInstance(data["brick_counts"], dict)
 
 

--- a/backend/tests/test_queue.py
+++ b/backend/tests/test_queue.py
@@ -33,11 +33,11 @@ class QueueTests(unittest.TestCase):
                 "gltf_url": None,
                 "brick_counts": {},
             }
-            job = q.enqueue(worker.generate_job, "cube", 1)
+            job = q.enqueue(worker.generate_job, "cube", 1, None)
             SimpleWorker([q], connection=redis_conn).work(burst=True)
             self.assertTrue(job.is_finished)
             self.assertEqual(job.result["png_url"], "/static/x/preview.png")
-            mock_gen.assert_called_once()
+            mock_gen.assert_called_once_with("cube", 1, None)
 
 
 if __name__ == "__main__":  # pragma: no cover

--- a/backend/worker.py
+++ b/backend/worker.py
@@ -7,9 +7,13 @@ from backend.detector import detect_inventory
 QUEUE_NAME = "legogpt"
 
 
-def generate_job(prompt: str, seed: int | None = 42) -> dict:
+def generate_job(
+    prompt: str,
+    seed: int | None = 42,
+    inventory_filter: dict[str, int] | None = None,
+) -> dict:
     """Background job that runs the model and returns file URLs."""
-    return generate_lego_model(prompt, seed)
+    return generate_lego_model(prompt, seed, inventory_filter)
 
 
 def detect_job(image_b64: str) -> dict:

--- a/docs/PROJECT_BACKLOG.md
+++ b/docs/PROJECT_BACKLOG.md
@@ -7,7 +7,7 @@
 | B‑2 | v0.5 | Build `detector/` micro‑service, Dockerfile, RQ worker | CV lead | ⬜ |
 | B‑3 | v0.5 | Add `/detect_inventory` endpoint in Gateway + tests | Backend | **Done** |
 | B‑4 | v0.5 | Front‑end camera / upload workflow + inventory table | FE | ⬜ |
-| B‑5 | v0.5 | Pass `inventory_filter` into `inference.generate()` | Backend | ⬜ |
+| B‑5 | v0.5 | Pass `inventory_filter` into `inference.generate()` | Backend | **Done** |
 | B‑6 | v0.5 | E2E Cypress test: photo fixture → constrained build | QA | ⬜ |
 | B-01 | **M** | Dockerise backend & worker           | **Done** | GPU-aware image, `docker compose dev` |
 | B-02 | **M** | React PWA scaffold                   | **Done** | Vite + Tailwind, SW cache |


### PR DESCRIPTION
## Summary
- allow inventory_filter to be passed down from the API to inference
- validate inventory_filter in HTTP server
- update worker and queue tests for new parameter
- document the new option in README and backlog
- note feature in CHANGELOG

## Testing
- `python -m unittest discover -v`