### PR TITLE
Fix offline setup for frontend

### DIFF
--- a/.codex/setup.sh
+++ b/.codex/setup.sh
@@ -6,8 +6,10 @@ if [ -f .gitmodules ]; then
   git submodule update --init --recursive
 fi
 
-# Install OR-Tools before network access is disabled
-python -m pip install --no-cache-dir ortools
+# Install Python dependencies before network access is disabled
+python -m pip install --no-cache-dir ortools redis rq
 
-# Install front-end packages while network access is available
-pnpm install --dir frontend
+# Pre-fetch front-end packages while network access is available
+pnpm fetch --dir frontend
+# Install using the cached packages once network access is removed
+pnpm install --offline --dir frontend

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,8 +23,9 @@ This project is developed by a **human owner (Jeff) plus ChatGPT‑4o “dev age
 brew install git gh docker --cask docker docker-compose node@20 pnpm
 git clone git@github.com:JGAVEN/Lego-GPT.git
 cd Lego-GPT && git submodule update --init
-pnpm install --dir frontend  # run automatically in the dev container
-python -m pip install --editable ./backend
+pnpm fetch --dir frontend && pnpm install --offline --dir frontend \
+  # run automatically in the dev container's setup script
+python -m pip install --editable ./backend  # backend + worker deps installed in setup
 ```
 
 See **docs/ARCHITECTURE.md** for more details.

--- a/README.md
+++ b/README.md
@@ -126,8 +126,9 @@ Default rate limit is `5` generate requests per token per minute (configurable v
 
 1. **One atomic branch per ticket** (`feature/<ticket-slug>`).
 2. Follow `docs/PROJECT_BACKLOG.md` for ticket IDs and size.
-3. Front-end dependencies are installed automatically during setup
-   (`pnpm install --dir frontend`). Run `npm run lint` after editing UI code.
+3. Front-end dependencies are installed automatically during setup via
+   `pnpm fetch --dir frontend && pnpm install --offline --dir frontend`.
+   Run `npm run lint` after editing UI code.
 4. Run `python -m unittest discover -v` before pushing. The test suite uses
    Python's built-in `unittest` module—no need for `pytest`.
 5. Update `docs/CHANGELOG.md` after each merge to `main`.


### PR DESCRIPTION
## Summary
- prefetch frontend packages in setup script
- install redis & rq with OR-Tools before network drop
- document new setup steps in README and CONTRIBUTING

## Testing
- `python -m unittest discover -v`