### PR TITLE
Fix CI by installing pnpm

### DIFF
--- a/.codex/setup.sh
+++ b/.codex/setup.sh
@@ -9,6 +9,10 @@ fi
 # Install Python dependencies before network access is disabled
 python -m pip install --no-cache-dir ortools redis rq
 
+# Install pnpm for front-end package management
+corepack enable
+corepack prepare pnpm@10.11.0 --activate
+
 # Pre-fetch front-end packages while network access is available
 pnpm fetch --prod=false --dir frontend
 # Install using the cached packages once network access is removed

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,11 @@ jobs:
         with:
           node-version: '18'
 
+      - name: Install pnpm
+        run: |
+          corepack enable
+          corepack prepare pnpm@10.11.0 --activate
+
       - name: Install front-end deps
         run: pnpm install --frozen-lockfile --dir frontend
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@
   malformed.
 
 ### Fixed
-* _None yet_
+* CI installs pnpm before running front-end tests.
 
 # Changelog
 

--- a/README.md
+++ b/README.md
@@ -36,6 +36,9 @@ real-life building via a built-in Three.js viewer.
 git clone https://github.com/JGAVEN/Lego-GPT.git
 cd Lego-GPT
 
+# Install pnpm (requires Node.js)
+npm install -g pnpm
+
 # Install backend dependencies (including optional test tools)
 python -m pip install --editable ./backend[test]
 
@@ -64,6 +67,8 @@ pnpm --dir frontend run dev    # http://localhost:5173
 
 > **Prerequisites**
 > * Python 3.11+
+> * Node.js 18+
+> * pnpm package manager
 
 &nbsp;
 


### PR DESCRIPTION
## Summary
- install pnpm during CI using `corepack`
- provision pnpm in dev setup script
- document Node/pnpm prerequisites and quick-start steps
- note CI fix in changelog

## Testing
- `python -m unittest discover -v`
- `pnpm install --no-frozen-lockfile --dir frontend` *(fails: EHOSTUNREACH)*
- `pnpm --dir frontend run test:e2e` *(fails: EHOSTUNREACH)*