### PR TITLE
Fix pnpm offline setup

### DIFF
--- a/.codex/setup.sh
+++ b/.codex/setup.sh
@@ -11,7 +11,7 @@ python -m pip install --no-cache-dir ortools redis rq
 
 # Install pnpm for front-end package management
 corepack enable
-corepack prepare pnpm@10.11.0 --activate
+corepack prepare pnpm@10.5.2 --activate
 
 # Pre-fetch front-end packages while network access is available
 pnpm fetch --prod=false --dir frontend

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 * Updated architecture and backlog documentation.
 * `/detect_inventory` now validates base64 input and returns HTTP 400 if
   malformed.
+* Pinned pnpm version to 10.5.2 for offline setup reliability.
 
 ### Fixed
 * CI installs pnpm before running front-end tests.

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ git clone https://github.com/JGAVEN/Lego-GPT.git
 cd Lego-GPT
 
 # Install pnpm (requires Node.js)
-npm install -g pnpm
+npm install -g pnpm@10.5.2
 
 # Install backend dependencies (including optional test tools)
 python -m pip install --editable ./backend[test]

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -28,5 +28,5 @@
     "typescript-eslint": "^8.30.1",
     "vite": "^6.3.5"
   },
-  "packageManager": "pnpm@10.11.0+sha512.6540583f41cc5f628eb3d9773ecee802f4f9ef9923cc45b69890fb47991d4b092964694ec3a4f738a420c918a333062c8b925d312f42e4f0c263eb603551f977"
+  "packageManager": "pnpm@10.5.2"
 }


### PR DESCRIPTION
## Summary
- pin pnpm to 10.5.2 for offline installs
- document the version change
- update setup script to use the pinned version

## Testing
- `python -m unittest discover -v`
