### PR TITLE
Add front-end lint step to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,22 @@ jobs:
       - name: Run tests
         run: |
           python -m unittest discover -v
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Set up pnpm
+        uses: pnpm/action-setup@v2
+        with:
+          version: 10.5.2
+
+      - name: Install front-end dependencies
+        run: pnpm install --frozen-lockfile --dir frontend
+
+      - name: Run front-end lint
+        run: pnpm --dir frontend run lint
       # 6. (Optional) Build dev Docker image
       # - name: Build Docker image
       #   run: docker build -f Dockerfile.dev -t lego-gpt-dev .

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * React `InventoryScanner` component and `useDetectInventory` hook.
 * Optional `fakeredis` dependency for running queue tests
 * `detector/` micro-service and Dockerfile for inventory detection
+* GitHub Actions CI lints front-end code with pnpm
 
 ### Changed
 * Updated architecture and backlog documentation.

--- a/README.md
+++ b/README.md
@@ -140,7 +140,8 @@ Default rate limit is `5` generate requests per token per minute (configurable v
 2. Follow `docs/PROJECT_BACKLOG.md` for ticket IDs and size.
 3. Front-end dependencies are installed automatically during setup via
    `pnpm fetch --prod=false --dir frontend && pnpm install --offline --dir frontend`.
-   Run `npm run lint` after editing UI code.
+   Run `npm run lint` after editing UI code. CI also runs this lint step
+   automatically.
 4. Run `python -m unittest discover -v` before pushing. The test suite uses
    Python's built-in `unittest` module—no need for `pytest`.
 5. Update `docs/CHANGELOG.md` after each merge to `main`.

--- a/docs/PROJECT_BACKLOG.md
+++ b/docs/PROJECT_BACKLOG.md
@@ -21,6 +21,7 @@
 | B-10 | **M** | Add MIT licence text                 | **Done** | Root and vendor licence files added |
 | B-11 | **M** | Align API contract                   | **Done** | POST returns `job_id`; GET `/generate/{job_id}` yields `{png_url, ldr_url, brick_counts}` |
 | B-12 | **XS** | JWT auth unit tests                  | **Done** | encode/decode helpers |
+| B-13 | **XS** | Front-end lint step in CI            | **Done** | pnpm runs ESLint in workflow |
 |------|-----|---------------------------------------|--------|-------|
 | S-10 | **M** | Introduce `ILPSolver` interface & refactor | **Done** | Branch `feature/solver-refactor` |
 | S-11 | **M** | Implement OR-Tools MIP constraints   | **Done** | Connectivity filter added; solver computes stable subset |
@@ -31,4 +32,4 @@
 * **Pri** – MoSCoW priority (**M**ust, **S**hould, **C**ould, **W**on’t-Have-Now).
 * **Status** – Open / WIP / Blocked / Done.
 
-_Last updated 2025-05-26_
+_Last updated 2025-05-27_


### PR DESCRIPTION
## Summary
- run ESLint for the PWA in GitHub Actions
- mention CI linting in the README
- track the CI update in the backlog and changelog

## Testing
- `python -m pytest -q`