### PR TITLE
Fix pnpm lint failure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 * `detector/` micro-service and Dockerfile for inventory detection
 * GitHub Actions CI lints front-end code with pnpm
 * `scripts/setup_frontend.sh` installs UI dependencies for offline use
+* Setup script now retries offline install before fetching packages
 
 ### Changed
 * Updated architecture and backlog documentation.

--- a/README.md
+++ b/README.md
@@ -36,7 +36,9 @@ real-life building via a built-in Three.js viewer.
 git clone https://github.com/JGAVEN/Lego-GPT.git
 cd Lego-GPT
 
-# Install front-end dependencies (requires network access once)
+# Install front-end dependencies.
+# The script installs from the local pnpm store if possible and fetches from
+# the registry when online. Run it once with network access.
 ./scripts/setup_frontend.sh
 
 # Install pnpm (requires Node.js)
@@ -142,7 +144,9 @@ Default rate limit is `5` generate requests per token per minute (configurable v
 1. **One atomic branch per ticket** (`feature/<ticket-slug>`).
 2. Follow `docs/PROJECT_BACKLOG.md` for ticket IDs and size.
 3. Front-end dependencies are installed via `scripts/setup_frontend.sh`.
-   If packages are missing, re-run the script or `pnpm install --dir frontend`.
+   The script first attempts an offline install and fetches from the registry if needed.
+   Run it once with network access (`pnpm install --dir frontend` works too) so
+   future lints and dev builds work offline.
    Run `npm run lint` after editing UI code. CI also runs this lint step automatically.
 4. Run `python -m unittest discover -v` before pushing. The test suite uses
    Python's built-in `unittest` module—no need for `pytest`.

--- a/scripts/setup_frontend.sh
+++ b/scripts/setup_frontend.sh
@@ -4,8 +4,22 @@
 set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 REPO_ROOT="$(dirname "$SCRIPT_DIR")"
-# Fetch packages to pnpm store
-pnpm fetch --prod=false --dir "$REPO_ROOT/frontend"
-# Install dependencies using offline store
-pnpm install --offline --dir "$REPO_ROOT/frontend"
-echo "Front-end dependencies installed."
+cd "$REPO_ROOT/frontend"
+
+# Attempt offline install first. If packages are missing, fall back to
+# fetching them from the registry (requires network) and reinstall
+# from the local store.
+if pnpm install --offline; then
+  echo "Front-end dependencies installed from offline store."
+  exit 0
+fi
+
+echo "Offline install failed – fetching packages from registry..."
+if curl -I --max-time 5 https://registry.npmjs.org >/dev/null 2>&1; then
+  pnpm fetch --prod=false
+  pnpm install --offline
+  echo "Front-end dependencies installed."
+else
+  echo "Network unavailable. Connect to the internet and re-run this script." >&2
+  exit 1
+fi


### PR DESCRIPTION
## Summary
- improve offline setup script
- document offline pnpm install
- update changelog

## Testing
- `python -m unittest discover -v`
- `bash scripts/setup_frontend.sh` *(fails: network unavailable)*