### PR TITLE
Improve frontend setup messaging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 * GitHub Actions CI lints front-end code with pnpm
 * `scripts/setup_frontend.sh` installs UI dependencies for offline use
 * Setup script now retries offline install before fetching packages
+* Clearer message when the pnpm store lacks packages and no network is available
 
 ### Changed
 * Updated architecture and backlog documentation.

--- a/README.md
+++ b/README.md
@@ -39,6 +39,8 @@ cd Lego-GPT
 # Install front-end dependencies.
 # The script installs from the local pnpm store if possible and fetches from
 # the registry when online. Run it once with network access.
+# Running it offline before the store is populated will print instructions
+# to retry with network access.
 ./scripts/setup_frontend.sh
 
 # Install pnpm (requires Node.js)
@@ -147,6 +149,8 @@ Default rate limit is `5` generate requests per token per minute (configurable v
    The script first attempts an offline install and fetches from the registry if needed.
    Run it once with network access (`pnpm install --dir frontend` works too) so
    future lints and dev builds work offline.
+   Running it before this first networked install will show a message
+   explaining that the pnpm store is missing.
    Run `npm run lint` after editing UI code. CI also runs this lint step automatically.
 4. Run `python -m unittest discover -v` before pushing. The test suite uses
    Python's built-in `unittest` module—no need for `pytest`.

--- a/scripts/setup_frontend.sh
+++ b/scripts/setup_frontend.sh
@@ -14,12 +14,17 @@ if pnpm install --offline; then
   exit 0
 fi
 
-echo "Offline install failed – fetching packages from registry..."
+echo "Offline install failed – attempting to fetch packages from registry..."
 if curl -I --max-time 5 https://registry.npmjs.org >/dev/null 2>&1; then
   pnpm fetch --prod=false
   pnpm install --offline
   echo "Front-end dependencies installed."
-else
-  echo "Network unavailable. Connect to the internet and re-run this script." >&2
-  exit 1
+  exit 0
 fi
+
+cat >&2 <<'EOF'
+Network unavailable and the pnpm store is missing required packages.
+Run this script once with network access to populate the store.
+See README.md for details.
+EOF
+exit 1


### PR DESCRIPTION
## Summary
- clarify README instructions for frontend setup
- explain initial network requirement in contributing guidelines
- improve scripts/setup_frontend.sh message when offline
- document update in CHANGELOG

## Testing
- `python -m unittest discover -v`