### PR TITLE
Add server-side base64 validation for inventory detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,8 +15,8 @@
 
 ### Changed
 * Updated architecture and backlog documentation.
-* `/detect_inventory` now validates base64 input and returns HTTP 400 if
-  malformed.
+* `/detect_inventory` endpoint now validates base64 input server-side and
+  returns `HTTP 400` if malformed.
 * Pinned pnpm version to 10.5.2 for offline setup reliability.
 * Dev Docker images now install backend dependencies automatically.
 

--- a/README.md
+++ b/README.md
@@ -141,7 +141,8 @@ pass it to the `LDrawViewer` React component for interactive viewing.
 ### Detect Brick Inventory
 
 `POST /detect_inventory` expects `{ "image": "<base64>" }` with a **valid**
-base64 string and returns `{ "job_id": "xyz" }`. Poll
+base64 string and returns `{ "job_id": "xyz" }`. Invalid base64 yields
+`HTTP 400`. Poll
 `GET /detect_inventory/{job_id}` for the result:
 
 ```json

--- a/backend/server.py
+++ b/backend/server.py
@@ -160,6 +160,14 @@ class Handler(BaseHTTPRequestHandler):
                 self.send_error(400, "Invalid JSON")
                 return
             image_b64 = payload.get("image", "")
+            try:
+                # Validate base64 before queuing the job
+                from backend.detector import _validate_base64
+
+                _validate_base64(image_b64)
+            except Exception:
+                self.send_error(400, "Invalid image data")
+                return
             job_obj = queue.enqueue(detect_job, image_b64)
             self._send_json({"job_id": job_obj.id})
             return

--- a/backend/tests/test_server.py
+++ b/backend/tests/test_server.py
@@ -145,6 +145,20 @@ class ServerTests(unittest.TestCase):
         self.assertEqual(payload["job_id"], "xyz")
         mock_queue.enqueue.assert_called_once()
 
+    @patch("backend.server.queue")
+    def test_detect_inventory_invalid_base64(self, mock_queue):
+        mock_job = MagicMock(id="xyz")
+        mock_queue.enqueue.return_value = mock_job
+
+        status, _ = self._request(
+            "POST",
+            "/detect_inventory",
+            body=b'{"image":"@@@"}',
+            token=self.token,
+        )
+        self.assertEqual(status, 400)
+        mock_queue.enqueue.assert_not_called()
+
 
 if __name__ == "__main__":  # pragma: no cover
     unittest.main()


### PR DESCRIPTION
## Summary
- validate base64 images in `/detect_inventory` before queuing jobs
- test invalid base64 handling for server endpoint
- document 400 response for invalid images
- clarify CHANGELOG entry

## Testing
- `python -m unittest discover -v`