### PR TITLE
Expose backend version via /health

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 * Setup script now retries offline install before fetching packages
 * Clearer message when the pnpm store lacks packages and no network is available
 * `scripts/generate_jwt.py` helper for creating auth tokens
+* `/health` endpoint now returns backend `version`
 
 ### Changed
 * Updated architecture and backlog documentation.

--- a/README.md
+++ b/README.md
@@ -81,6 +81,8 @@ docker compose up --build
 ```
 
 The API will be available at http://localhost:8000/health.
+The `/health` endpoint responds with `{ "ok": true, "version": "x.y.z" }` so you
+can verify the backend version.
 
 > **Prerequisites**
 > * Python 3.11+
@@ -104,6 +106,9 @@ docker-compose.yml  Dev stack (backend + detector workers)
 &nbsp;
 
 ## 5. API Contract
+
+`GET /health` returns `{ "ok": true, "version": "x.y.z" }` and can be used to
+verify that the backend is running.
 
 `POST /generate` requires an `Authorization: Bearer <token>` header and accepts a JSON body:
 

--- a/backend/__init__.py
+++ b/backend/__init__.py
@@ -1,0 +1,10 @@
+"""Backend package for Lego GPT."""
+
+from importlib.metadata import PackageNotFoundError, version
+
+try:  # pragma: no cover - during editable installs
+    __version__ = version("lego-gpt-backend")
+except PackageNotFoundError:  # pragma: no cover - fallback for tests
+    __version__ = "0.0.0"
+
+__all__ = ["__version__"]

--- a/backend/api.py
+++ b/backend/api.py
@@ -1,13 +1,14 @@
 """Minimal API functions for offline use."""
 from pathlib import Path
 from backend.inference import generate
+from backend import __version__
 
 STATIC_ROOT = Path(__file__).parent / "static"
 
 
 def health() -> dict:
-    """Simple liveness check used by the HTTP server."""
-    return {"ok": True}
+    """Return service liveness and version information."""
+    return {"ok": True, "version": __version__}
 
 
 def generate_lego_model(

--- a/backend/tests/test_server.py
+++ b/backend/tests/test_server.py
@@ -61,6 +61,7 @@ class ServerTests(unittest.TestCase):
         self.assertEqual(status, 200)
         payload = json.loads(data)
         self.assertTrue(payload.get("ok"))
+        self.assertRegex(payload.get("version", ""), r"\d+\.\d+\.\d+")
 
     def test_static_path_traversal_blocked(self):
         status, _ = self._request("GET", "/static/../server.py")

--- a/backend/tests/test_version.py
+++ b/backend/tests/test_version.py
@@ -1,0 +1,18 @@
+import sys
+import unittest
+from pathlib import Path
+
+project_root = Path(__file__).resolve().parents[2]
+if str(project_root) not in sys.path:
+    sys.path.insert(0, str(project_root))
+
+import backend  # noqa: E402
+
+
+class VersionTests(unittest.TestCase):
+    def test_version_format(self):
+        self.assertRegex(backend.__version__, r"\d+\.\d+\.\d+")
+
+
+if __name__ == "__main__":  # pragma: no cover
+    unittest.main()


### PR DESCRIPTION
## Summary
- add `__version__` in backend package
- include version in `/health` response
- document health endpoint and new field
- test version retrieval

## Testing
- `python -m unittest discover -v backend/tests`