### PR TITLE
Improve dev proxy routes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@
 * Dev Docker images now install backend dependencies automatically.
 * `setup_frontend.sh` now exits if `pnpm` is missing and README quick-start
   installs pnpm before running the script.
+* Vite dev server proxies `/detect_inventory` and `/static` to the backend for
+  seamless development.
 
 ### Fixed
 * CI installs pnpm before running front-end tests.

--- a/README.md
+++ b/README.md
@@ -70,6 +70,10 @@ python scripts/generate_jwt.py --secret mysecret --sub dev
 pnpm --dir frontend run dev    # http://localhost:5173
 ```
 
+The Vite dev server proxies `/generate`, `/detect_inventory`, and `/static`
+requests to `http://localhost:8000` so the PWA works against your local backend
+without CORS issues.
+
 ### Docker Compose
 
 Alternatively, start the API and detector workers in Docker containers. The

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -9,6 +9,14 @@ export default defineConfig({
         target: "http://localhost:8000",
         changeOrigin: true,
       },
+      "/detect_inventory": {
+        target: "http://localhost:8000",
+        changeOrigin: true,
+      },
+      "/static": {
+        target: "http://localhost:8000",
+        changeOrigin: true,
+      },
     },
   },
 });


### PR DESCRIPTION
## Summary
- proxy `/detect_inventory` and `/static` in Vite config
- document the proxy behaviour in the README
- note the new proxy routes in the changelog

## Testing
- `python -m unittest discover -v`