### PR TITLE
Add CLI options for API server host/port

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 * Clearer message when the pnpm store lacks packages and no network is available
 * `scripts/generate_jwt.py` helper for creating auth tokens
 * `/health` endpoint now returns backend `version`
+* `backend/server.py` accepts `--host` and `--port` CLI options (or `HOST`/`PORT` env vars)
 
 ### Changed
 * Updated architecture and backlog documentation.

--- a/README.md
+++ b/README.md
@@ -61,7 +61,9 @@ python detector/worker.py
 # Launch the API server in another
 export JWT_SECRET=mysecret         # auth secret
 export BRICK_INVENTORY=backend/inventory.json  # optional inventory
-python backend/server.py    # http://localhost:8000/health
+python backend/server.py --host 0.0.0.0 --port 8000    # http://localhost:8000/health
+# The `--host` and `--port` options override the defaults and can also be
+# provided via `HOST` and `PORT` environment variables.
 
 # Generate a JWT for requests
 python scripts/generate_jwt.py --secret mysecret --sub dev

--- a/backend/server.py
+++ b/backend/server.py
@@ -181,5 +181,25 @@ def run(host: str = "0.0.0.0", port: int = 8000):
     server.serve_forever()
 
 
-if __name__ == "__main__":
-    run()
+def main() -> None:
+    """Parse CLI args and run the HTTP server."""
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Run Lego GPT API server")
+    parser.add_argument(
+        "--host",
+        default=os.getenv("HOST", "0.0.0.0"),
+        help="Host interface to bind (default: 0.0.0.0 or HOST env var)",
+    )
+    parser.add_argument(
+        "--port",
+        type=int,
+        default=int(os.getenv("PORT", "8000")),
+        help="Port number (default: 8000 or PORT env var)",
+    )
+    args = parser.parse_args()
+    run(args.host, args.port)
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry point
+    main()


### PR DESCRIPTION
## Summary
- allow configuring host/port via CLI or env vars in `backend/server.py`
- document CLI options in README
- note server CLI options in changelog

## Testing
- `python -m unittest discover -v`