### PR TITLE
Add --version flag to server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 * `scripts/generate_jwt.py` helper for creating auth tokens
 * `/health` endpoint now returns backend `version`
 * `backend/server.py` accepts `--host` and `--port` CLI options (or `HOST`/`PORT` env vars)
+* `backend/server.py` now supports `--version` to print the backend version
 
 ### Changed
 * Updated architecture and backlog documentation.

--- a/README.md
+++ b/README.md
@@ -64,7 +64,8 @@ export BRICK_INVENTORY=backend/inventory.json  # optional inventory
 export DETECTOR_MODEL=detector/model.pt       # optional YOLOv8 weights
 python backend/server.py --host 0.0.0.0 --port 8000    # http://localhost:8000/health
 # The `--host` and `--port` options override the defaults and can also be
-# provided via `HOST` and `PORT` environment variables.
+# provided via `HOST` and `PORT` environment variables. Use `--version` to
+# print the backend version and exit.
 
 # Generate a JWT for requests
 python scripts/generate_jwt.py --secret mysecret --sub dev

--- a/backend/server.py
+++ b/backend/server.py
@@ -9,6 +9,7 @@ from rq import Queue, Job
 from backend.api import health, STATIC_ROOT
 from backend.worker import QUEUE_NAME, generate_job, detect_job
 from backend.auth import decode as decode_jwt
+from backend import __version__
 
 
 REDIS_URL = os.getenv("REDIS_URL", "redis://localhost:6379/0")
@@ -197,7 +198,15 @@ def main() -> None:
         default=int(os.getenv("PORT", "8000")),
         help="Port number (default: 8000 or PORT env var)",
     )
+    parser.add_argument(
+        "--version",
+        action="store_true",
+        help="Print backend version and exit",
+    )
     args = parser.parse_args()
+    if args.version:
+        print(__version__)
+        return
     run(args.host, args.port)
 
 

--- a/backend/tests/test_cli.py
+++ b/backend/tests/test_cli.py
@@ -1,0 +1,24 @@
+import io
+import sys
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+project_root = Path(__file__).resolve().parents[2]
+if str(project_root) not in sys.path:
+    sys.path.insert(0, str(project_root))
+
+import backend
+import backend.server as server
+
+
+class CLITests(unittest.TestCase):
+    def test_version_flag(self):
+        with patch.object(sys, 'argv', ['server', '--version']):
+            with patch('sys.stdout', new=io.StringIO()) as fake_out:
+                server.main()
+                self.assertEqual(fake_out.getvalue().strip(), backend.__version__)
+
+
+if __name__ == '__main__':  # pragma: no cover
+    unittest.main()


### PR DESCRIPTION
## Summary
- expose backend version via `--version` CLI flag
- document usage of new flag in README
- record change in CHANGELOG
- test CLI option

## Testing
- `python -m unittest discover -v`