### PR TITLE
Fix pytest import issue and docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 * `/health` endpoint now returns backend `version`
 * `backend/server.py` accepts `--host` and `--port` CLI options (or `HOST`/`PORT` env vars)
 * `backend/server.py` now supports `--version` to print the backend version
+* `pytest` now works via `backend/tests/conftest.py` (optional)
 
 ### Changed
 * Updated architecture and backlog documentation.

--- a/README.md
+++ b/README.md
@@ -177,7 +177,7 @@ Default rate limit is `5` generate requests per token per minute (configurable v
    explaining that the pnpm store is missing.
    Run `npm run lint` after editing UI code. CI also runs this lint step automatically.
 4. Run `python -m unittest discover -v` before pushing. The test suite uses
-   Python's built-in `unittest` module—no need for `pytest`.
+   Python's built-in `unittest` module. `pytest` is optional and works too.
 5. Update `docs/CHANGELOG.md` after each merge to `main`.
 
 See `docs/CONTRIBUTING.md` for full workflow, coding style, and commit-message

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -1,0 +1,8 @@
+import sys
+from pathlib import Path
+
+project_root = Path(__file__).resolve().parents[2]
+vendor_root = project_root / "vendor"
+for p in (project_root, vendor_root):
+    if str(p) not in sys.path:
+        sys.path.insert(0, str(p))

--- a/backend/tests/test_cli.py
+++ b/backend/tests/test_cli.py
@@ -5,8 +5,10 @@ from pathlib import Path
 from unittest.mock import patch
 
 project_root = Path(__file__).resolve().parents[2]
-if str(project_root) not in sys.path:
-    sys.path.insert(0, str(project_root))
+vendor_root = project_root / "vendor"
+for p in (project_root, vendor_root):
+    if str(p) not in sys.path:
+        sys.path.insert(0, str(p))
 
 import backend
 import backend.server as server


### PR DESCRIPTION
## Summary
- ensure vendor modules are on the path when running pytest
- document optional pytest usage in README
- update changelog

## Testing
- `python -m unittest discover -v`
- `python -m pytest`