### PR TITLE
Add CLI scripts for server and workers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## Unreleased
 
+## [0.5.1] – 2025-05-28
+### Added
+* Console scripts `lego-gpt-server`, `lego-gpt-worker` and `lego-detect-worker`.
+  Documentation updated to show their usage.
+
 ## [0.5.0] – 2025-05-27
 ### Added
 * **Photo‑based brick inventory detection** feature (YOLOv8 detector, `/detect_inventory` API, front‑end scan workflow).

--- a/README.md
+++ b/README.md
@@ -54,15 +54,15 @@ python -m pip install --editable ./backend[test]
 # docker run -p 6379:6379 -d redis:7
 
 # Launch the RQ worker in one terminal
-python backend/worker.py
+lego-gpt-worker
 # Launch the detector worker in another
-python detector/worker.py
+lego-detect-worker
 
 # Launch the API server in another
 export JWT_SECRET=mysecret         # auth secret
 export BRICK_INVENTORY=backend/inventory.json  # optional inventory
 export DETECTOR_MODEL=detector/model.pt       # optional YOLOv8 weights
-python backend/server.py --host 0.0.0.0 --port 8000    # http://localhost:8000/health
+lego-gpt-server --host 0.0.0.0 --port 8000    # http://localhost:8000/health
 # The `--host` and `--port` options override the defaults and can also be
 # provided via `HOST` and `PORT` environment variables. Use `--version` to
 # print the backend version and exit.

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "lego-gpt-backend"
-version = "0.5.0"
+version = "0.5.1"
 requires-python = ">=3.11"
 dependencies = [
     "redis>=5",
@@ -16,3 +16,8 @@ cv = [
     "ultralytics>=8",
     "pillow>=10",
 ]
+
+[project.scripts]
+lego-gpt-server = "backend.server:main"
+lego-gpt-worker = "backend.worker:run_worker"
+lego-detect-worker = "detector.worker:run_detector"

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -41,7 +41,7 @@ clusters not connected to the ground.
 |------------|-------------------------------------------------------------------------------------------------|--------------|
 | **Front-end** | Prompt form, spinner, preview image, 3-D viewer, offline PWA shell                            | React 18, Vite, Three.js (`LDrawLoader` from CDN) |
 | **API**       | Auth, rate-limit, enqueue job, expose static file links                                       | Python http.server stub |
-| **Worker**    | `backend/worker.py` runs `rq` jobs, lazy-loads LegoGPT, routes bricks → solver, saves PNG + LDR | Python 3.12, CUDA 12.2, HF `transformers` |
+| **Worker**    | `lego-gpt-worker` runs `rq` jobs, lazy-loads LegoGPT, routes bricks → solver, saves PNG + LDR | Python 3.12, CUDA 12.2, HF `transformers` |
 | **Solver**    | Verify physical stability via MIP (connectivity, gravity, overhang)                           | OR-Tools / HiGHS |
 | **Storage**   | Serve artifacts, 7-day TTL, promote to S3 / Cloudflare R2 in prod                             | Local `/static` → CDN later |
 
@@ -81,9 +81,10 @@ Adds a YOLOv8‑based computer‑vision worker that converts user‑supplied pho
 The API validates that the `image` field contains a valid base64 string and
 returns HTTP 400 for malformed data.
 
-The worker lives in the top-level `detector/` directory and can run as a standalone
-micro-service via `detector/Dockerfile.dev`. The dev Dockerfiles now install all
-backend dependencies so the container starts without extra setup.
+The worker lives in the top-level `detector/` directory and can run as a
+standalone micro‑service via `detector/Dockerfile.dev`. Start it locally with the
+`lego-detect-worker` console script. The dev Dockerfiles install all backend
+dependencies so the container starts without extra setup.
 
 Set the `DETECTOR_MODEL` environment variable to the path of the YOLOv8
 weights file.  If the variable is unset or the `ultralytics` package is

--- a/docs/PROJECT_BACKLOG.md
+++ b/docs/PROJECT_BACKLOG.md
@@ -23,6 +23,7 @@
 | B-12 | **XS** | JWT auth unit tests                  | **Done** | encode/decode helpers |
 | B-13 | **XS** | Front-end lint step in CI            | **Done** | pnpm runs ESLint in workflow |
 | B-14 | **S** | YOLOv8 model auto-loader            | **Done** | `DETECTOR_MODEL` env var selects weights |
+| B-15 | **XS** | Console scripts for server/worker   | **Done** | `lego-gpt-server`, `lego-gpt-worker`, `lego-detect-worker` |
 |------|-----|---------------------------------------|--------|-------|
 | S-10 | **M** | Introduce `ILPSolver` interface & refactor | **Done** | Branch `feature/solver-refactor` |
 | S-11 | **M** | Implement OR-Tools MIP constraints   | **Done** | Connectivity filter added; solver computes stable subset |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,4 +1,4 @@
 [project]
 name = "lego-gpt"
-version = "0.5.0"
+version = "0.5.1"
 requires-python = ">=3.11"


### PR DESCRIPTION
## Summary
- add console entry points for server and workers
- bump version to 0.5.1
- document new commands in README and ARCHITECTURE
- update backlog and changelog

## Testing
- `python -m unittest discover -v`