### PR TITLE
Centralize static file path constant

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## Unreleased
 ### Added
 * Dev container setup installs backend dependencies including fakeredis for tests.
+### Changed
+* Static file path constant moved to `backend` package for consistency.
 ## [0.5.2] – 2025-05-29
 ### Added
 * `lint_frontend.js` skips UI lint when dependencies are missing offline.

--- a/backend/__init__.py
+++ b/backend/__init__.py
@@ -1,10 +1,14 @@
 """Backend package for Lego GPT."""
 
 from importlib.metadata import PackageNotFoundError, version
+from pathlib import Path
 
 try:  # pragma: no cover - during editable installs
     __version__ = version("lego-gpt-backend")
 except PackageNotFoundError:  # pragma: no cover - fallback for tests
     __version__ = "0.0.0"
 
-__all__ = ["__version__"]
+PACKAGE_DIR = Path(__file__).parent
+STATIC_ROOT = PACKAGE_DIR / "static"
+
+__all__ = ["__version__", "STATIC_ROOT"]

--- a/backend/api.py
+++ b/backend/api.py
@@ -1,9 +1,7 @@
 """Minimal API functions for offline use."""
 from pathlib import Path
 from backend.inference import generate
-from backend import __version__
-
-STATIC_ROOT = Path(__file__).parent / "static"
+from backend import __version__, STATIC_ROOT
 
 
 def health() -> dict:

--- a/backend/inference.py
+++ b/backend/inference.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import uuid
 from pathlib import Path
+from backend import STATIC_ROOT
 
 from backend.export import ldr_to_gltf
 from backend.inventory import filter_counts
@@ -57,7 +58,7 @@ def generate(prompt: str, seed: int | None = None, inventory_filter: dict[str, i
     result = model.generate(prompt, seed=seed)
 
     run_id = str(uuid.uuid4())
-    output_dir = Path("backend/static") / run_id
+    output_dir = STATIC_ROOT / run_id
     output_dir.mkdir(parents=True, exist_ok=True)
 
     png_path = output_dir / "preview.png"

--- a/backend/server.py
+++ b/backend/server.py
@@ -6,7 +6,8 @@ import time
 from http.server import HTTPServer, BaseHTTPRequestHandler
 from redis import Redis
 from rq import Queue, Job
-from backend.api import health, STATIC_ROOT
+from backend.api import health
+from backend import STATIC_ROOT
 from backend.worker import QUEUE_NAME, generate_job, detect_job
 from backend.auth import decode as decode_jwt
 from backend import __version__


### PR DESCRIPTION
## Summary
- add `STATIC_ROOT` constant to `backend` package
- update API, server, and inference modules to use new constant
- record change in `CHANGELOG`

## Testing
- `python -m unittest discover -v backend/tests`