### PR TITLE
Bump to v0.5.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 ## Unreleased
+
+## [0.5.3] – 2025-05-30
 ### Added
 * Dev container setup installs backend dependencies including fakeredis for tests.
 ### Changed

--- a/README.md
+++ b/README.md
@@ -68,6 +68,8 @@ lego-gpt-server --host 0.0.0.0 --port 8000    # http://localhost:8000/health
 # The `--host` and `--port` options override the defaults and can also be
 # provided via `HOST` and `PORT` environment variables. Use `--version` to
 # print the backend version and exit.
+# Generated assets are written to `backend/static/{uuid}/` by default. Set
+# `STATIC_ROOT` to override the directory.
 
 # Generate a JWT for requests
 python scripts/generate_jwt.py --secret mysecret --sub dev
@@ -98,7 +100,7 @@ can verify the backend version.
 
 > **Prerequisites**
 > * Python 3.11+
-> * Node.js 18+
+> * Node.js 20+
 > * pnpm package manager
 
 &nbsp;

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "lego-gpt-backend"
-version = "0.5.2"
+version = "0.5.3"
 requires-python = ">=3.11"
 dependencies = [
     "redis>=5",

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -53,7 +53,8 @@ clusters not connected to the ground.
 2. API validates, enqueues job on the Redis/RQ queue → ✅ returns `job_id`.
 3. Worker loads LegoGPT, **calls solver shim** ➜ bricks verified.
 4. Inventory filter trims the brick list using `BRICK_INVENTORY`.
-5. Worker writes `preview.png`, `model.ldr`, and `model.gltf` to `/static/{uuid}/`.
+5. Worker writes `preview.png`, `model.ldr`, and `model.gltf` to
+   `backend/static/{uuid}/` by default (`STATIC_ROOT` can override).
 6. When finished, a GET on `/generate/{job_id}` returns `{png_url, ldr_url, gltf_url, brick_counts}`.
 7. Client shows PNG immediately; Three.js lazily loads LDR → interactive viewer.
    The `LDrawLoader` module is fetched from a CDN at runtime.

--- a/docs/PROJECT_BACKLOG.md
+++ b/docs/PROJECT_BACKLOG.md
@@ -34,4 +34,4 @@
 * **Pri** – MoSCoW priority (**M**ust, **S**hould, **C**ould, **W**on’t-Have-Now).
 * **Status** – Open / WIP / Blocked / Done.
 
-_Last updated 2025-05-29_
+_Last updated 2025-05-30_

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "lego-gpt"
-version = "0.5.2"
+version = "0.5.3"
 requires-python = ">=3.11"
 
 [build-system]


### PR DESCRIPTION
## Summary
- bump project version to 0.5.3
- update README with STATIC_ROOT note and Node 20+ requirement
- clarify static asset path in architecture docs
- keep project backlog date current

## Testing
- `python -m unittest discover backend/tests -v`