### PR TITLE
Make STATIC_ROOT configurable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## Unreleased
 
+## [0.5.4] – 2025-05-31
+### Changed
+* `STATIC_ROOT` can now be set via environment variable to control where
+  generated assets are written.
+
 ## [0.5.3] – 2025-05-30
 ### Added
 * Dev container setup installs backend dependencies including fakeredis for tests.

--- a/README.md
+++ b/README.md
@@ -68,8 +68,9 @@ lego-gpt-server --host 0.0.0.0 --port 8000    # http://localhost:8000/health
 # The `--host` and `--port` options override the defaults and can also be
 # provided via `HOST` and `PORT` environment variables. Use `--version` to
 # print the backend version and exit.
-# Generated assets are written to `backend/static/{uuid}/` by default. Set
-# `STATIC_ROOT` to override the directory.
+# Generated assets are written to `backend/static/{uuid}/` by default.
+# Set the `STATIC_ROOT` environment variable before starting the server
+# to override the directory.
 
 # Generate a JWT for requests
 python scripts/generate_jwt.py --secret mysecret --sub dev

--- a/backend/__init__.py
+++ b/backend/__init__.py
@@ -2,6 +2,7 @@
 
 from importlib.metadata import PackageNotFoundError, version
 from pathlib import Path
+import os
 
 try:  # pragma: no cover - during editable installs
     __version__ = version("lego-gpt-backend")
@@ -9,6 +10,10 @@ except PackageNotFoundError:  # pragma: no cover - fallback for tests
     __version__ = "0.0.0"
 
 PACKAGE_DIR = Path(__file__).parent
-STATIC_ROOT = PACKAGE_DIR / "static"
+_env_static = os.getenv("STATIC_ROOT")
+if _env_static:
+    STATIC_ROOT = Path(_env_static).expanduser().resolve()
+else:
+    STATIC_ROOT = (PACKAGE_DIR / "static").resolve()
 
 __all__ = ["__version__", "STATIC_ROOT"]

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "lego-gpt-backend"
-version = "0.5.3"
+version = "0.5.4"
 requires-python = ">=3.11"
 dependencies = [
     "redis>=5",

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -54,7 +54,8 @@ clusters not connected to the ground.
 3. Worker loads LegoGPT, **calls solver shim** ➜ bricks verified.
 4. Inventory filter trims the brick list using `BRICK_INVENTORY`.
 5. Worker writes `preview.png`, `model.ldr`, and `model.gltf` to
-   `backend/static/{uuid}/` by default (`STATIC_ROOT` can override).
+   `backend/static/{uuid}/` by default. Set the `STATIC_ROOT` environment
+   variable before launch to change this location.
 6. When finished, a GET on `/generate/{job_id}` returns `{png_url, ldr_url, gltf_url, brick_counts}`.
 7. Client shows PNG immediately; Three.js lazily loads LDR → interactive viewer.
    The `LDrawLoader` module is fetched from a CDN at runtime.
@@ -71,7 +72,7 @@ clusters not connected to the ground.
 
 ---
 
-_Last updated 2025-05-29_
+_Last updated 2025-05-31_
 
 ---
 

--- a/docs/PROJECT_BACKLOG.md
+++ b/docs/PROJECT_BACKLOG.md
@@ -34,4 +34,4 @@
 * **Pri** – MoSCoW priority (**M**ust, **S**hould, **C**ould, **W**on’t-Have-Now).
 * **Status** – Open / WIP / Blocked / Done.
 
-_Last updated 2025-05-30_
+_Last updated 2025-05-31_

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "lego-gpt"
-version = "0.5.3"
+version = "0.5.4"
 requires-python = ">=3.11"
 
 [build-system]


### PR DESCRIPTION
## Summary
- allow overriding `STATIC_ROOT` via environment variable
- document new env var usage in README and architecture docs
- bump version to 0.5.4
- update backlog and changelog

## Testing
- `python -m unittest discover -v`