### PR TITLE
Add STATIC_ROOT environment configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 ## Unreleased
+### Added
+* `STATIC_ROOT` environment variable allows overriding the default
+  `backend/static` directory.
 
 ## [0.5.4] – 2025-05-31
 ### Added

--- a/README.md
+++ b/README.md
@@ -68,8 +68,8 @@ lego-gpt-server --host 0.0.0.0 --port 8000    # http://localhost:8000/health
 # The `--host` and `--port` options override the defaults and can also be
 # provided via `HOST` and `PORT` environment variables. Use `--version` to
 # print the backend version and exit.
-# Generated assets are written to `backend/static/{uuid}/` by default. Set
-# `STATIC_ROOT` to override the directory.
+# Generated assets are written to `backend/static/{uuid}/` by default. Set the
+# `STATIC_ROOT` environment variable to override the directory.
 
 # Generate a JWT for requests
 python scripts/generate_jwt.py --secret mysecret --sub dev

--- a/backend/__init__.py
+++ b/backend/__init__.py
@@ -2,6 +2,7 @@
 
 from importlib.metadata import PackageNotFoundError, version
 from pathlib import Path
+import os
 
 try:  # pragma: no cover - during editable installs
     __version__ = version("lego-gpt-backend")
@@ -9,6 +10,8 @@ except PackageNotFoundError:  # pragma: no cover - fallback for tests
     __version__ = "0.0.0"
 
 PACKAGE_DIR = Path(__file__).parent
-STATIC_ROOT = PACKAGE_DIR / "static"
+_env_static = os.getenv("STATIC_ROOT")
+STATIC_ROOT = Path(_env_static) if _env_static else PACKAGE_DIR / "static"
+STATIC_ROOT = STATIC_ROOT.resolve()
 
 __all__ = ["__version__", "STATIC_ROOT"]

--- a/backend/tests/test_static_root.py
+++ b/backend/tests/test_static_root.py
@@ -1,0 +1,22 @@
+import importlib
+import os
+import sys
+import unittest
+from pathlib import Path
+
+project_root = Path(__file__).resolve().parents[2]
+if str(project_root) not in sys.path:
+    sys.path.insert(0, str(project_root))
+
+class StaticRootEnvTests(unittest.TestCase):
+    def test_env_overrides_default(self):
+        tmp_dir = Path("/tmp/legogpt-test-static")
+        os.environ["STATIC_ROOT"] = str(tmp_dir)
+        import backend
+        importlib.reload(backend)
+        self.assertEqual(backend.STATIC_ROOT, tmp_dir.resolve())
+        del os.environ["STATIC_ROOT"]
+        importlib.reload(backend)
+
+if __name__ == "__main__":
+    unittest.main()

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -54,7 +54,8 @@ clusters not connected to the ground.
 3. Worker loads LegoGPT, **calls solver shim** ➜ bricks verified.
 4. Inventory filter trims the brick list using `BRICK_INVENTORY`.
 5. Worker writes `preview.png`, `model.ldr`, and `model.gltf` to
-   `backend/static/{uuid}/` by default (`STATIC_ROOT` can override).
+   `backend/static/{uuid}/` by default. Set the `STATIC_ROOT` environment
+   variable to override the directory.
 6. When finished, a GET on `/generate/{job_id}` returns `{png_url, ldr_url, gltf_url, brick_counts}`.
 7. Client shows PNG immediately; Three.js lazily loads LDR → interactive viewer.
    The `LDrawLoader` module is fetched from a CDN at runtime.


### PR DESCRIPTION
## Summary
- allow overriding static directory via `STATIC_ROOT`
- document new variable in README and architecture docs
- note the change in `CHANGELOG.md`
- test that the environment variable is respected

## Testing
- `python -m unittest discover -v`