### PR TITLE
Add redis-url CLI flag for worker scripts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## Unreleased
 
+## [0.5.6] – 2025-05-31
+### Added
+* `--redis-url` option for `lego-gpt-worker` and `lego-detect-worker`.
+### Changed
+* Project version bumped to 0.5.6.
+
 ## [0.5.5] – 2025-05-31
 ### Added
 * `STATIC_ROOT` environment variable allows overriding the default

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ real-life building via a built-in Three.js viewer.
 | 📦 **Inventory filter** | Limits brick counts using `BRICK_INVENTORY` JSON or per-request `inventory_filter` |
 | 🆕 **Photo‑based brick inventory detection** – YOLOv8 detector + `/detect_inventory` API | Scan your loose bricks and generate builds you can actually build |
 | 🛡️ **Static file handler sanitized** | Blocks path traversal in `/static` requests |
-| 🆕 **Console scripts** for API and workers (`lego-gpt-server`, `lego-gpt-worker`, `lego-detect-worker`) | Easier local development & Docker entrypoints |
+| 🆕 **Console scripts** for API and workers (`lego-gpt-server`, `lego-gpt-worker`, `lego-detect-worker`) | Easier local development & Docker entrypoints; workers accept `--redis-url` |
 
 &nbsp;
 
@@ -54,11 +54,14 @@ python -m pip install --editable ./backend[test]
 
 # Start Redis (local or Docker)
 # docker run -p 6379:6379 -d redis:7
+# Optionally set the Redis URL for server and workers
+export REDIS_URL=redis://localhost:6379/0
 
 # Launch the RQ worker in one terminal
-lego-gpt-worker
+# ``--redis-url`` overrides the REDIS_URL env var
+lego-gpt-worker --redis-url "$REDIS_URL"
 # Launch the detector worker in another
-lego-detect-worker
+lego-detect-worker --redis-url "$REDIS_URL"
 
 # Launch the API server in another
 export JWT_SECRET=mysecret         # auth secret

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "lego-gpt-backend"
-version = "0.5.5"
+version = "0.5.6"
 requires-python = ">=3.11"
 dependencies = [
     "redis>=5",
@@ -19,8 +19,8 @@ cv = [
 
 [project.scripts]
 lego-gpt-server = "backend.server:main"
-lego-gpt-worker = "backend.worker:run_worker"
-lego-detect-worker = "detector.worker:run_detector"
+lego-gpt-worker = "backend.worker:main"
+lego-detect-worker = "detector.worker:main"
 lego-detect-train = "detector.train:main"
 
 [build-system]

--- a/detector/worker.py
+++ b/detector/worker.py
@@ -1,6 +1,7 @@
 """RQ worker dedicated to brick inventory detection."""
 from redis import Redis
 from rq import Worker, Connection
+import os
 
 from backend.worker import QUEUE_NAME, detect_job
 
@@ -13,5 +14,20 @@ def run_detector(redis_url: str = "redis://localhost:6379/0") -> None:
         worker.work()
 
 
-if __name__ == "__main__":  # pragma: no cover
-    run_detector()
+def main(argv: list[str] | None = None) -> None:
+    """CLI entry point for ``lego-detect-worker``."""
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Run Lego GPT detector worker")
+    parser.add_argument(
+        "--redis-url",
+        default=os.getenv("REDIS_URL", "redis://localhost:6379/0"),
+        help="Redis connection URL (default: env REDIS_URL or redis://localhost:6379/0)",
+    )
+    args = parser.parse_args(argv)
+
+    run_detector(args.redis_url)
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry
+    main()

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -41,7 +41,7 @@ clusters not connected to the ground.
 |------------|-------------------------------------------------------------------------------------------------|--------------|
 | **Front-end** | Prompt form, spinner, preview image, 3-D viewer, offline PWA shell                            | React 18, Vite, Three.js (`LDrawLoader` from CDN) |
 | **API**       | Auth, rate-limit, enqueue job, expose static file links                                       | Python http.server stub |
-| **Worker**    | `lego-gpt-worker` runs `rq` jobs, lazy-loads LegoGPT, routes bricks → solver, saves PNG + LDR | Python 3.12, CUDA 12.2, HF `transformers` |
+| **Worker**    | `lego-gpt-worker` runs `rq` jobs, lazy-loads LegoGPT, routes bricks → solver, saves PNG + LDR (use `--redis-url` to override the queue) | Python 3.12, CUDA 12.2, HF `transformers` |
 | **Solver**    | Verify physical stability via MIP (connectivity, gravity, overhang)                           | OR-Tools / HiGHS |
 | **Storage**   | Serve artifacts, 7-day TTL, promote to S3 / Cloudflare R2 in prod                             | Local `/static` → CDN later |
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "lego-gpt"
-version = "0.5.5"
+version = "0.5.6"
 requires-python = ">=3.11"
 
 [build-system]


### PR DESCRIPTION
## Summary
- add `--redis-url` CLI option to `lego-gpt-worker` and `lego-detect-worker`
- expose new `main()` entry points in `backend/pyproject.toml`
- document the flag in README and architecture docs
- bump version to 0.5.6 and update changelog

## Testing
- `python -m unittest discover -v`