### PR TITLE
Improve docker stack and bump version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 ## Unreleased
 
+## [0.5.7] – 2025-05-31
+### Added
+* Docker Compose stack now includes a dedicated generation worker.
+* Docker images use the new console scripts as default entrypoints.
+### Changed
+* Project version bumped to 0.5.7.
+
 ## [0.5.6] – 2025-05-31
 ### Added
 * `--redis-url` option for `lego-gpt-worker` and `lego-detect-worker`.

--- a/README.md
+++ b/README.md
@@ -89,13 +89,15 @@ without CORS issues.
 
 ### Docker Compose
 
-Alternatively, start the API and detector workers in Docker containers. The
-dev Dockerfiles install all backend dependencies so the stack works
-out‑of‑the‑box:
+Alternatively, start the API server along with the generation and detector
+workers in Docker containers. The dev Dockerfiles install all backend
+dependencies so the stack works out‑of‑the‑box:
 
 ```bash
 docker compose up --build
 ```
+
+This spins up the API server, a generation worker and the detector worker.
 
 The API will be available at http://localhost:8000/health.
 The `/health` endpoint responds with `{ "ok": true, "version": "x.y.z" }` so you
@@ -129,7 +131,7 @@ docs/               Project docs  (ARCHITECTURE, PROJECT_BACKLOG, CHANGELOG…)
 frontend/           React + Vite PWA scaffold
 vendor/legogpt/     Vendored CMU LegoGPT library
 detector/           Brick-detector micro-service worker
-docker-compose.yml  Dev stack (backend + detector workers)
+docker-compose.yml  Dev stack (server + workers)
 ```
 
 &nbsp;

--- a/backend/Dockerfile.dev
+++ b/backend/Dockerfile.dev
@@ -16,4 +16,4 @@ RUN pip install --no-cache-dir --editable ./backend
 
 WORKDIR /app/backend
 EXPOSE 8000
-CMD ["python", "server.py"]
+CMD ["lego-gpt-server"]

--- a/backend/docker-compose.yml
+++ b/backend/docker-compose.yml
@@ -10,4 +10,12 @@ services:
       - .:/app/backend
     ports:
       - "8000:8000"
-    command: python server.py
+    command: lego-gpt-server
+  worker:
+    build:
+      context: .
+      dockerfile: Dockerfile.dev
+    working_dir: /app/backend
+    volumes:
+      - .:/app/backend
+    command: lego-gpt-worker

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "lego-gpt-backend"
-version = "0.5.6"
+version = "0.5.7"
 requires-python = ">=3.11"
 dependencies = [
     "redis>=5",

--- a/detector/Dockerfile.dev
+++ b/detector/Dockerfile.dev
@@ -13,4 +13,4 @@ COPY vendor/legogpt/data /app/legogpt/data
 
 RUN pip install --no-cache-dir --editable ./backend
 
-CMD ["python", "-m", "detector.worker"]
+CMD ["lego-detect-worker"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,7 +9,15 @@ services:
       - ./backend:/app/backend:delegated
     ports:
       - "8000:8000"
-    command: python server.py
+    command: lego-gpt-server
+  worker:
+    build:
+      context: .
+      dockerfile: backend/Dockerfile.dev
+    working_dir: /app/backend
+    volumes:
+      - ./backend:/app/backend:delegated
+    command: lego-gpt-worker
   detector:
     build:
       context: .
@@ -18,4 +26,4 @@ services:
     volumes:
       - ./backend:/app/backend:delegated
       - ./detector:/app/detector:delegated
-    command: python -m detector.worker
+    command: lego-detect-worker

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "lego-gpt"
-version = "0.5.6"
+version = "0.5.7"
 requires-python = ">=3.11"
 
 [build-system]


### PR DESCRIPTION
## Summary
- update Dockerfiles to use console scripts by default
- add generation worker service to docker-compose
- bump project version to 0.5.7
- document new compose stack in README
- record changes in CHANGELOG

## Testing
- `python -m unittest discover -v`