### PR TITLE
Add configurable queue name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 ## Unreleased
 
+## [0.5.8] – 2025-05-31
+### Added
+* `QUEUE_NAME` env var and `--queue` option allow custom RQ queue names for
+  server and workers.
+### Changed
+* Project version bumped to 0.5.8.
+
 ## [0.5.7] – 2025-05-31
 ### Added
 * Docker Compose stack now includes a dedicated generation worker.

--- a/README.md
+++ b/README.md
@@ -59,15 +59,18 @@ export REDIS_URL=redis://localhost:6379/0
 
 # Launch the RQ worker in one terminal
 # ``--redis-url`` overrides the REDIS_URL env var
-lego-gpt-worker --redis-url "$REDIS_URL"
+# Optional ``--queue`` overrides the QUEUE_NAME env var
+export QUEUE_NAME=legogpt
+lego-gpt-worker --redis-url "$REDIS_URL" --queue "$QUEUE_NAME"
 # Launch the detector worker in another
-lego-detect-worker --redis-url "$REDIS_URL"
+lego-detect-worker --redis-url "$REDIS_URL" --queue "$QUEUE_NAME"
 
 # Launch the API server in another
 export JWT_SECRET=mysecret         # auth secret
 export BRICK_INVENTORY=backend/inventory.json  # optional inventory
 export DETECTOR_MODEL=detector/model.pt       # optional YOLOv8 weights
 lego-gpt-server --host 0.0.0.0 --port 8000    # http://localhost:8000/health
+# ``--queue`` overrides the QUEUE_NAME env var
 # The `--host` and `--port` options override the defaults and can also be
 # provided via `HOST` and `PORT` environment variables. Use `--version` to
 # print the backend version and exit.

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "lego-gpt-backend"
-version = "0.5.7"
+version = "0.5.8"
 requires-python = ">=3.11"
 dependencies = [
     "redis>=5",

--- a/backend/tests/test_queue_name_env.py
+++ b/backend/tests/test_queue_name_env.py
@@ -1,0 +1,25 @@
+import importlib
+import os
+import sys
+import unittest
+from pathlib import Path
+
+project_root = Path(__file__).resolve().parents[2]
+if str(project_root) not in sys.path:
+    sys.path.insert(0, str(project_root))
+
+
+class QueueNameEnvTests(unittest.TestCase):
+    def test_env_overrides_queue_name(self):
+        os.environ["QUEUE_NAME"] = "testq"
+        import backend.worker as worker
+
+        importlib.reload(worker)
+        self.assertEqual(worker.QUEUE_NAME, "testq")
+        del os.environ["QUEUE_NAME"]
+        importlib.reload(worker)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    unittest.main()
+

--- a/detector/worker.py
+++ b/detector/worker.py
@@ -6,11 +6,14 @@ import os
 from backend.worker import QUEUE_NAME, detect_job
 
 
-def run_detector(redis_url: str = "redis://localhost:6379/0") -> None:
+def run_detector(
+    redis_url: str = "redis://localhost:6379/0",
+    queue_name: str = QUEUE_NAME,
+) -> None:
     """Run an RQ worker that processes detection jobs."""
     conn = Redis.from_url(redis_url)
     with Connection(conn):
-        worker = Worker([QUEUE_NAME])
+        worker = Worker([queue_name])
         worker.work()
 
 
@@ -24,9 +27,14 @@ def main(argv: list[str] | None = None) -> None:
         default=os.getenv("REDIS_URL", "redis://localhost:6379/0"),
         help="Redis connection URL (default: env REDIS_URL or redis://localhost:6379/0)",
     )
+    parser.add_argument(
+        "--queue",
+        default=os.getenv("QUEUE_NAME", QUEUE_NAME),
+        help="RQ queue name (default: env QUEUE_NAME or 'legogpt')",
+    )
     args = parser.parse_args(argv)
 
-    run_detector(args.redis_url)
+    run_detector(args.redis_url, args.queue)
 
 
 if __name__ == "__main__":  # pragma: no cover - CLI entry

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -41,7 +41,7 @@ clusters not connected to the ground.
 |------------|-------------------------------------------------------------------------------------------------|--------------|
 | **Front-end** | Prompt form, spinner, preview image, 3-D viewer, offline PWA shell                            | React 18, Vite, Three.js (`LDrawLoader` from CDN) |
 | **API**       | Auth, rate-limit, enqueue job, expose static file links                                       | Python http.server stub |
-| **Worker**    | `lego-gpt-worker` runs `rq` jobs, lazy-loads LegoGPT, routes bricks → solver, saves PNG + LDR (use `--redis-url` to override the queue) | Python 3.12, CUDA 12.2, HF `transformers` |
+| **Worker**    | `lego-gpt-worker` runs `rq` jobs, lazy-loads LegoGPT, routes bricks → solver, saves PNG + LDR (use `--redis-url` and `--queue` to override defaults) | Python 3.12, CUDA 12.2, HF `transformers` |
 | **Solver**    | Verify physical stability via MIP (connectivity, gravity, overhang)                           | OR-Tools / HiGHS |
 | **Storage**   | Serve artifacts, 7-day TTL, promote to S3 / Cloudflare R2 in prod                             | Local `/static` → CDN later |
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "lego-gpt"
-version = "0.5.7"
+version = "0.5.8"
 requires-python = ">=3.11"
 
 [build-system]


### PR DESCRIPTION
## Summary
- allow custom queue name via `QUEUE_NAME` env var and `--queue` CLI option
- update server and workers to accept queue name
- document new option in README and architecture docs
- bump version to 0.5.8
- test environment override for queue name

## Testing
- `python -m unittest discover -v`