### PR TITLE
Add CLI options test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [0.5.11] – 2025-06-03
+### Added
+* Unit test covering server CLI options.
+
+### Changed
+* Project version bumped to 0.5.11.
+
 ## [0.5.10] – 2025-06-02
 ### Added
 * CLI options `--redis-url`, `--jwt-secret` and `--rate-limit` for `lego-gpt-server`.

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "lego-gpt-backend"
-version = "0.5.10"
+version = "0.5.11"
 requires-python = ">=3.11"
 dependencies = [
     "redis>=5",

--- a/backend/tests/test_cli.py
+++ b/backend/tests/test_cli.py
@@ -21,6 +21,28 @@ class CLITests(unittest.TestCase):
                 server.main()
                 self.assertEqual(fake_out.getvalue().strip(), backend.__version__)
 
+    def test_cli_options_parsed(self):
+        argv = [
+            'server',
+            '--host', '1.2.3.4',
+            '--port', '1234',
+            '--queue', 'testq',
+            '--redis-url', 'redis://host:9999/1',
+            '--jwt-secret', 'tok',
+            '--rate-limit', '7',
+        ]
+        with patch.object(sys, 'argv', argv):
+            with patch('backend.server.run') as mock_run:
+                server.main()
+                mock_run.assert_called_once_with(
+                    '1.2.3.4',
+                    1234,
+                    'testq',
+                    'redis://host:9999/1',
+                    'tok',
+                    7,
+                )
+
 
 if __name__ == '__main__':  # pragma: no cover
     unittest.main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "lego-gpt"
-version = "0.5.10"
+version = "0.5.11"
 requires-python = ">=3.11"
 
 [build-system]


### PR DESCRIPTION
## Summary
- add unit test to ensure `lego-gpt-server` parses CLI options
- bump project version to 0.5.11
- document new version in CHANGELOG

## Testing
- `ruff check backend detector`
- `python -m unittest discover -v`