### PR TITLE
Add version flag to worker CLIs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## [0.5.12] – 2025-06-04
+### Added
+* `--version` flag for `lego-gpt-worker` and `lego-detect-worker`.
+* Unit tests covering worker CLI options.
+
+### Changed
+* Project version bumped to 0.5.12.
+
 ## [0.5.11] – 2025-06-03
 ### Added
 * Unit test covering server CLI options.

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ real-life building via a built-in Three.js viewer.
 | 📦 **Inventory filter** | Limits brick counts using `BRICK_INVENTORY` JSON or per-request `inventory_filter` |
 | 🆕 **Photo‑based brick inventory detection** – YOLOv8 detector + `/detect_inventory` API | Scan your loose bricks and generate builds you can actually build |
 | 🛡️ **Static file handler sanitized** | Blocks path traversal in `/static` requests |
-| 🆕 **Console scripts** for API and workers (`lego-gpt-server`, `lego-gpt-worker`, `lego-detect-worker`) | Easier local development & Docker entrypoints; workers accept `--redis-url` |
+| 🆕 **Console scripts** for API and workers (`lego-gpt-server`, `lego-gpt-worker`, `lego-detect-worker`) | Easier local development & Docker entrypoints; workers accept `--redis-url` and `--version` |
 | 🛠️ **Ruff linting** for backend code | Consistent style via `ruff check` locally and in CI |
 
 &nbsp;
@@ -65,6 +65,7 @@ export QUEUE_NAME=legogpt
 lego-gpt-worker --redis-url "$REDIS_URL" --queue "$QUEUE_NAME"
 # Launch the detector worker in another
 lego-detect-worker --redis-url "$REDIS_URL" --queue "$QUEUE_NAME"
+# Append ``--version`` to either worker command to print the version and exit
 
 # Launch the API server in another
 export JWT_SECRET=mysecret         # auth secret

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "lego-gpt-backend"
-version = "0.5.11"
+version = "0.5.12"
 requires-python = ">=3.11"
 dependencies = [
     "redis>=5",

--- a/backend/tests/test_worker_cli.py
+++ b/backend/tests/test_worker_cli.py
@@ -1,0 +1,55 @@
+import io
+import sys
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+project_root = Path(__file__).resolve().parents[2]
+vendor_root = project_root / "vendor"
+for p in (project_root, vendor_root):
+    if str(p) not in sys.path:
+        sys.path.insert(0, str(p))
+
+import backend
+import backend.worker as worker
+import detector.worker as detect_worker
+
+
+class WorkerCLITests(unittest.TestCase):
+    def test_worker_version_flag(self):
+        with patch.object(sys, 'argv', ['worker', '--version']):
+            with patch('sys.stdout', new=io.StringIO()) as fake_out:
+                worker.main()
+                self.assertEqual(fake_out.getvalue().strip(), backend.__version__)
+
+    def test_worker_options_parsed(self):
+        argv = [
+            'worker',
+            '--redis-url', 'redis://host:9999/1',
+            '--queue', 'testq',
+        ]
+        with patch.object(sys, 'argv', argv):
+            with patch('backend.worker.run_worker') as mock_run:
+                worker.main()
+                mock_run.assert_called_once_with('redis://host:9999/1', 'testq')
+
+    def test_detector_worker_version_flag(self):
+        with patch.object(sys, 'argv', ['detector-worker', '--version']):
+            with patch('sys.stdout', new=io.StringIO()) as fake_out:
+                detect_worker.main()
+                self.assertEqual(fake_out.getvalue().strip(), backend.__version__)
+
+    def test_detector_worker_options_parsed(self):
+        argv = [
+            'detector-worker',
+            '--redis-url', 'redis://host:9999/1',
+            '--queue', 'detq',
+        ]
+        with patch.object(sys, 'argv', argv):
+            with patch('detector.worker.run_detector') as mock_run:
+                detect_worker.main()
+                mock_run.assert_called_once_with('redis://host:9999/1', 'detq')
+
+
+if __name__ == '__main__':  # pragma: no cover
+    unittest.main()

--- a/backend/worker.py
+++ b/backend/worker.py
@@ -4,6 +4,7 @@ from rq import Worker, Connection
 import os
 from backend.api import generate_lego_model
 from backend.detector import detect_inventory
+from backend import __version__
 
 QUEUE_NAME = os.getenv("QUEUE_NAME", "legogpt")
 
@@ -49,7 +50,16 @@ def main(argv: list[str] | None = None) -> None:
         default=os.getenv("QUEUE_NAME", QUEUE_NAME),
         help="RQ queue name (default: env QUEUE_NAME or 'legogpt')",
     )
+    parser.add_argument(
+        "--version",
+        action="store_true",
+        help="Print backend version and exit",
+    )
     args = parser.parse_args(argv)
+
+    if args.version:
+        print(__version__)
+        return
 
     run_worker(args.redis_url, args.queue)
 

--- a/detector/worker.py
+++ b/detector/worker.py
@@ -2,7 +2,7 @@
 from redis import Redis
 from rq import Worker, Connection
 import os
-
+from backend import __version__
 from backend.worker import QUEUE_NAME
 
 
@@ -32,7 +32,16 @@ def main(argv: list[str] | None = None) -> None:
         default=os.getenv("QUEUE_NAME", QUEUE_NAME),
         help="RQ queue name (default: env QUEUE_NAME or 'legogpt')",
     )
+    parser.add_argument(
+        "--version",
+        action="store_true",
+        help="Print backend version and exit",
+    )
     args = parser.parse_args(argv)
+
+    if args.version:
+        print(__version__)
+        return
 
     run_detector(args.redis_url, args.queue)
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -41,7 +41,7 @@ clusters not connected to the ground.
 |------------|-------------------------------------------------------------------------------------------------|--------------|
 | **Front-end** | Prompt form, spinner, preview image, 3-D viewer, offline PWA shell                            | React 18, Vite, Three.js (`LDrawLoader` from CDN) |
 | **API**       | Auth, rate-limit, enqueue job, expose static file links                                       | Python http.server stub |
-| **Worker**    | `lego-gpt-worker` runs `rq` jobs, lazy-loads LegoGPT, routes bricks → solver, saves PNG + LDR (use `--redis-url` and `--queue` to override defaults) | Python 3.12, CUDA 12.2, HF `transformers` |
+| **Worker**    | `lego-gpt-worker` runs `rq` jobs, lazy-loads LegoGPT, routes bricks → solver, saves PNG + LDR (use `--redis-url`, `--queue`, and `--version`) | Python 3.12, CUDA 12.2, HF `transformers` |
 | **Solver**    | Verify physical stability via MIP (connectivity, gravity, overhang)                           | OR-Tools / HiGHS |
 | **Storage**   | Serve artifacts, 7-day TTL, promote to S3 / Cloudflare R2 in prod                             | Local `/static` → CDN later |
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "lego-gpt"
-version = "0.5.11"
+version = "0.5.12"
 requires-python = ">=3.11"
 
 [build-system]


### PR DESCRIPTION
## Summary
- add `--version` option to `lego-gpt-worker` and `lego-detect-worker`
- cover worker CLI parsing with new tests
- document worker version flag in README and architecture guide
- bump package versions to 0.5.12
- update changelog

## Testing
- `ruff check backend detector`
- `python -m unittest discover -v`