### PR TITLE
Add configurable static URL prefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ real-life building via a built-in Three.js viewer.
 
 &nbsp;
 
-## 2. What’s New (2025-06-01)
+## 2. What’s New (2025-06-07)
 | Change | Impact |
 |--------|--------|
 | 🔄 **Open-source solver** – switched to **OR-Tools 9.10 + HiGHS**. | Runs licence-free everywhere (local dev, CI, containers). |
@@ -29,6 +29,8 @@ real-life building via a built-in Three.js viewer.
 | 🛡️ **Static file handler sanitized** | Blocks path traversal in `/static` requests |
 | 🆕 **Console scripts** for API and workers (`lego-gpt-server`, `lego-gpt-worker`, `lego-detect-worker`) | Easier local development & Docker entrypoints; workers accept `--redis-url` and `--version` |
 | 🛠️ **Ruff linting** for backend code | Consistent style via `ruff check` locally and in CI |
+| 🌍 **CORS configuration** via `--cors-origins` | Allows custom `Access-Control-Allow-Origin` |
+| 🔗 **Static URL prefix** configurable | Set `STATIC_URL_PREFIX` to point asset links at a CDN |
 
 &nbsp;
 
@@ -90,7 +92,8 @@ lego-gpt-server \
 # and exit.
 # Generated assets are written to `backend/static/{uuid}/` by default.
 # Pass ``--static-root <dir>`` or set the ``STATIC_ROOT`` environment
-# variable to override the directory.
+# variable to override the directory. ``STATIC_URL_PREFIX`` customises
+# the URL prefix returned in API responses (default: ``/static``).
 # Set ``CORS_ORIGINS`` or pass ``--cors-origins <origins>`` to control the
 # ``Access-Control-Allow-Origin`` header.
 

--- a/backend/__init__.py
+++ b/backend/__init__.py
@@ -14,4 +14,7 @@ _env_static = os.getenv("STATIC_ROOT")
 STATIC_ROOT = Path(_env_static) if _env_static else PACKAGE_DIR / "static"
 STATIC_ROOT = STATIC_ROOT.resolve()
 
-__all__ = ["__version__", "STATIC_ROOT"]
+# URL prefix returned for generated assets
+STATIC_URL_PREFIX = os.getenv("STATIC_URL_PREFIX", "/static")
+
+__all__ = ["__version__", "STATIC_ROOT", "STATIC_URL_PREFIX"]

--- a/backend/api.py
+++ b/backend/api.py
@@ -1,7 +1,7 @@
 """Minimal API functions for offline use."""
 from pathlib import Path
 from backend.inference import generate
-from backend import __version__, STATIC_ROOT
+from backend import __version__, STATIC_ROOT, STATIC_URL_PREFIX
 
 
 def health() -> dict:
@@ -17,15 +17,15 @@ def generate_lego_model(
         prompt, seed, inventory_filter
     )
     rel_png = Path(png_path).resolve().relative_to(STATIC_ROOT.parent)
-    png_url = f"/static/{rel_png.parent.name}/preview.png"
+    png_url = f"{STATIC_URL_PREFIX}/{rel_png.parent.name}/preview.png"
     ldr_url = None
     gltf_url = None
     if ldr_path:
         rel_ldr = Path(ldr_path).resolve().relative_to(STATIC_ROOT.parent)
-        ldr_url = f"/static/{rel_ldr.parent.name}/model.ldr"
+        ldr_url = f"{STATIC_URL_PREFIX}/{rel_ldr.parent.name}/model.ldr"
     if gltf_path:
         rel_gltf = Path(gltf_path).resolve().relative_to(STATIC_ROOT.parent)
-        gltf_url = f"/static/{rel_gltf.parent.name}/model.gltf"
+        gltf_url = f"{STATIC_URL_PREFIX}/{rel_gltf.parent.name}/model.gltf"
     return {
         "png_url": png_url,
         "ldr_url": ldr_url,

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "lego-gpt-backend"
-version = "0.5.13"
+version = "0.5.14"
 requires-python = ">=3.11"
 dependencies = [
     "redis>=5",

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -55,7 +55,9 @@ clusters not connected to the ground.
 4. Inventory filter trims the brick list using `BRICK_INVENTORY`.
 5. Worker writes `preview.png`, `model.ldr`, and `model.gltf` to
    `backend/static/{uuid}/` by default. Pass ``--static-root <dir>``
-   (or set ``STATIC_ROOT``) to override the directory.
+   (or set ``STATIC_ROOT``) to override the directory. Use
+   ``STATIC_URL_PREFIX`` to customise the URL prefix returned to the
+   client (defaults to ``/static``).
 6. When finished, a GET on `/generate/{job_id}` returns `{png_url, ldr_url, gltf_url, brick_counts}`.
 7. Client shows PNG immediately; Three.js lazily loads LDR → interactive viewer.
    The `LDrawLoader` module is fetched from a CDN at runtime.

--- a/docs/PROJECT_BACKLOG.md
+++ b/docs/PROJECT_BACKLOG.md
@@ -26,6 +26,8 @@
 | B-15 | **XS** | Console scripts for server/worker   | **Done** | `lego-gpt-server`, `lego-gpt-worker`, `lego-detect-worker` |
 | B-16 | **XS** | Ruff lint + CI step                 | **Done** | pyproject config + workflow |
 | B-17 | **XS** | Configurable CORS headers            | **Done** | `--cors-origins` CLI + tests |
+| B-18 | **S** | Customisable static URL prefix       | **Done** | `STATIC_URL_PREFIX` env var |
+| B-19 | **C** | Upload assets to S3/R2               | Open   | Optional CDN support |
 |------|-----|---------------------------------------|--------|-------|
 | S-10 | **M** | Introduce `ILPSolver` interface & refactor | **Done** | Branch `feature/solver-refactor` |
 | S-11 | **M** | Implement OR-Tools MIP constraints   | **Done** | Connectivity filter added; solver computes stable subset |
@@ -36,4 +38,4 @@
 * **Pri** – MoSCoW priority (**M**ust, **S**hould, **C**ould, **W**on’t-Have-Now).
 * **Status** – Open / WIP / Blocked / Done.
 
-_Last updated 2025-06-06_
+_Last updated 2025-06-07_

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "lego-gpt"
-version = "0.5.13"
+version = "0.5.14"
 requires-python = ">=3.11"
 
 [build-system]


### PR DESCRIPTION
## Summary
- allow setting STATIC_URL_PREFIX environment variable
- document asset URL prefix in README and ARCHITECTURE
- list new feature in project backlog
- bump version to 0.5.14

## Testing
- `python -m unittest discover -v`