### PR TITLE
Improve dev setup for linting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [0.5.16] – 2025-06-09
+### Added
+* `ruff` included in `backend[test]` extras for local linting.
+### Changed
+* Backend package version bumped to 0.5.16.
+
 ## [0.5.15] – 2025-06-08
 ### Added
 * Optional S3/R2 upload via `S3_BUCKET` and `S3_URL_PREFIX`.

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ npm install -g pnpm@10.5.2
 # to retry with network access. The script requires `pnpm` to be installed.
 ./scripts/setup_frontend.sh
 
-# Install backend dependencies (including optional test tools)
+# Install backend dependencies and dev tools (includes `ruff` for linting)
 python -m pip install --editable ./backend[test]
 # The dev container's setup script runs this automatically.
 

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "lego-gpt-backend"
-version = "0.5.15"
+version = "0.5.16"
 requires-python = ">=3.11"
 dependencies = [
     "redis>=5",
@@ -11,6 +11,7 @@ dependencies = [
 [project.optional-dependencies]
 test = [
     "fakeredis>=2.21",
+    "ruff>=0.4",
 ]
 cv = [
     "ultralytics>=8",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "lego-gpt"
-version = "0.5.15"
+version = "0.5.16"
 requires-python = ">=3.11"
 
 [build-system]


### PR DESCRIPTION
## Summary
- bump version to 0.5.16
- include `ruff` in backend test extra
- clarify README that dev tools (ruff) are installed
- document change in CHANGELOG

## Testing
- `ruff check backend detector`
- `./scripts/run_tests.sh`