### PR TITLE
Implement dotenv support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,6 @@
+# Example configuration loaded via python-dotenv
+# Copy to .env and adjust values as needed
+REDIS_URL=redis://localhost:6379/0
+JWT_SECRET=changeme
+RATE_LIMIT=5
+STATIC_URL_PREFIX=/static

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@
 ### Changed
 * Backend package version bumped to 0.5.18.
 
+## [0.5.19] – 2025-06-11
+### Added
+* `.env` configuration support via optional `python-dotenv`.
+* Example `.env.example` file.
+### Changed
+* Backend package version bumped to 0.5.19.
+
 ## [0.5.17] – 2025-06-09
 ### Added
 * `lego-gpt-cli` command-line client for interacting with the API.

--- a/README.md
+++ b/README.md
@@ -44,6 +44,8 @@ real-life building via a built-in Three.js viewer.
 git clone https://github.com/JGAVEN/Lego-GPT.git
 cd Lego-GPT
 
+# Optional: copy ``.env.example`` to ``.env`` and adjust settings.
+
 # Install pnpm (requires Node.js)
 npm install -g pnpm@10.5.2
 
@@ -55,7 +57,8 @@ npm install -g pnpm@10.5.2
 ./scripts/setup_frontend.sh
 
 # Install backend dependencies and dev tools (includes `ruff` for linting)
-python -m pip install --editable ./backend[test]
+# Add the `[env]` extra to enable `.env` configuration support
+python -m pip install --editable ./backend[test,env]
 # The dev container's setup script runs this automatically.
 
 # Start Redis (local or Docker)
@@ -82,6 +85,8 @@ export DETECTOR_MODEL=detector/model.pt       # optional YOLOv8 weights (or pass
 # ``--jwt-secret``, ``--redis-url`` and ``--rate-limit`` override the
 # corresponding environment variables. Use ``--log-level`` or ``LOG_LEVEL``
 # to control verbosity for server and workers.
+# Optionally place these variables in a ``.env`` file (see ``.env.example``).
+# The backend automatically loads it on startup.
 lego-gpt-server \
   --host 0.0.0.0 \
   --port 8000 \

--- a/backend/__init__.py
+++ b/backend/__init__.py
@@ -4,6 +4,21 @@ from importlib.metadata import PackageNotFoundError, version
 from pathlib import Path
 import os
 
+# Load environment variables from a `.env` file.
+# Prefer ``python-dotenv`` if available, otherwise fall back to a tiny loader.
+try:  # pragma: no cover - optional dependency
+    from dotenv import load_dotenv
+
+    load_dotenv()
+except Exception:  # pragma: no cover - ignore if missing
+    env_path = Path(".env")
+    if env_path.is_file():
+        for line in env_path.read_text().splitlines():
+            if not line or line.startswith("#") or "=" not in line:
+                continue
+            key, value = line.split("=", 1)
+            os.environ.setdefault(key.strip(), value.strip())
+
 try:  # pragma: no cover - during editable installs
     __version__ = version("lego-gpt-backend")
 except PackageNotFoundError:  # pragma: no cover - fallback for tests

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "lego-gpt-backend"
-version = "0.5.18"
+version = "0.5.19"
 requires-python = ">=3.11"
 dependencies = [
     "redis>=5",
@@ -19,6 +19,9 @@ cv = [
 ]
 s3 = [
     "boto3>=1.34",
+]
+env = [
+    "python-dotenv>=1",
 ]
 
 [project.scripts]

--- a/backend/tests/test_dotenv.py
+++ b/backend/tests/test_dotenv.py
@@ -1,0 +1,29 @@
+import importlib
+import os
+import sys
+import tempfile
+from pathlib import Path
+import unittest
+
+project_root = Path(__file__).resolve().parents[2]
+if str(project_root) not in sys.path:
+    sys.path.insert(0, str(project_root))
+
+class DotEnvTests(unittest.TestCase):
+    def test_dotenv_loaded(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmp_path = Path(tmpdir)
+            env_file = tmp_path / '.env'
+            env_file.write_text('STATIC_URL_PREFIX=/cdn\n')
+            cwd = os.getcwd()
+            try:
+                os.chdir(tmp_path)
+                os.environ.pop('STATIC_URL_PREFIX', None)
+                import backend
+                importlib.reload(backend)
+                self.assertEqual(backend.STATIC_URL_PREFIX, '/cdn')
+            finally:
+                os.chdir(cwd)
+
+if __name__ == '__main__':  # pragma: no cover
+    unittest.main()

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -63,6 +63,8 @@ clusters not connected to the ground.
 7. Client shows PNG immediately; Three.js lazily loads LDR → interactive viewer.
    The `LDrawLoader` module is fetched from a CDN at runtime.
 8. Set ``LOG_LEVEL`` or pass ``--log-level`` to server/workers to control logging verbosity.
+9. Environment variables can be placed in a ``.env`` file. If
+   ``python-dotenv`` is installed, the backend loads it automatically on startup.
 
 ---
 

--- a/docs/PROJECT_BACKLOG.md
+++ b/docs/PROJECT_BACKLOG.md
@@ -30,6 +30,7 @@
 | B-19 | **C** | Upload assets to S3/R2               | **Done** | Optional CDN support |
 | B-20 | **XS** | `lego-gpt-cli` command-line client    | **Done** | Python script to call the API |
 | B-21 | **XS** | CLI `--version` flag and tests        | **Done** | Unit tests cover the new flag |
+| B-22 | **XS** | `.env` configuration support          | **Done** | Load variables via python-dotenv |
 |------|-----|---------------------------------------|--------|-------|
 | S-10 | **M** | Introduce `ILPSolver` interface & refactor | **Done** | Branch `feature/solver-refactor` |
 | S-11 | **M** | Implement OR-Tools MIP constraints   | **Done** | Connectivity filter added; solver computes stable subset |
@@ -40,4 +41,4 @@
 * **Pri** – MoSCoW priority (**M**ust, **S**hould, **C**ould, **W**on’t-Have-Now).
 * **Status** – Open / WIP / Blocked / Done.
 
-_Last updated 2025-06-10_
+_Last updated 2025-06-11_

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "lego-gpt"
-version = "0.5.18"
+version = "0.5.19"
 requires-python = ">=3.11"
 
 [build-system]


### PR DESCRIPTION
## Summary
- add optional dotenv loading to backend package
- document `.env` usage and provide `.env.example`
- bump version to 0.5.19
- update architecture and backlog docs
- add unit test for dotenv loading

## Testing
- `./scripts/run_tests.sh`