### PR TITLE
Add cleanup script for static assets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@
 ### Changed
 * Backend package version bumped to 0.5.19.
 
+## [0.5.20] – 2025-06-12
+### Added
+* `lego-gpt-cleanup` script removes old static assets.
+### Changed
+* Backend package version bumped to 0.5.20.
+
 ## [0.5.17] – 2025-06-09
 ### Added
 * `lego-gpt-cli` command-line client for interacting with the API.

--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ real-life building via a built-in Three.js viewer.
 | 🔗 **Static URL prefix** configurable | Set `STATIC_URL_PREFIX` to point asset links at a CDN |
 | ☁️ **S3/R2 uploads** | Set `S3_BUCKET` and `S3_URL_PREFIX` to host assets in the cloud |
 | 🆕 **CLI `--version` flag + tests** | `lego-gpt-cli --version` shows backend version; automated tests ensure it works |
+| 🧹 **Cleanup script** (`lego-gpt-cleanup`) | Remove old asset directories |
 
 &nbsp;
 
@@ -121,6 +122,8 @@ pnpm --dir frontend run dev    # http://localhost:5173
 pnpm --dir frontend run lint
 # Lint backend code
 ruff check backend detector
+# Remove assets older than 7 days
+lego-gpt-cleanup --days 7
 ```
 
 ### Pre-commit Hooks

--- a/backend/__init__.py
+++ b/backend/__init__.py
@@ -22,7 +22,7 @@ except Exception:  # pragma: no cover - ignore if missing
 try:  # pragma: no cover - during editable installs
     __version__ = version("lego-gpt-backend")
 except PackageNotFoundError:  # pragma: no cover - fallback for tests
-    __version__ = "0.0.0"
+    __version__ = "0.5.20"
 
 PACKAGE_DIR = Path(__file__).parent
 _env_static = os.getenv("STATIC_ROOT")

--- a/backend/cleanup.py
+++ b/backend/cleanup.py
@@ -1,0 +1,48 @@
+"""Clean up generated static assets."""
+from __future__ import annotations
+
+import argparse
+import os
+import shutil
+import time
+from pathlib import Path
+
+from backend import STATIC_ROOT
+
+
+def cleanup(path: Path = STATIC_ROOT, days: int = 7) -> int:
+    """Remove subdirectories in *path* older than *days* days.
+
+    Returns the number of directories removed.
+    """
+    threshold = time.time() - days * 86400
+    count = 0
+    for item in path.iterdir():
+        if not item.is_dir():
+            continue
+        if item.stat().st_mtime < threshold:
+            shutil.rmtree(item, ignore_errors=True)
+            count += 1
+    return count
+
+
+def main(argv: list[str] | None = None) -> None:
+    parser = argparse.ArgumentParser(description="Remove old generated assets")
+    parser.add_argument(
+        "--path",
+        default=os.getenv("STATIC_ROOT", str(STATIC_ROOT)),
+        help="Directory containing generated assets",
+    )
+    parser.add_argument(
+        "--days",
+        type=int,
+        default=int(os.getenv("CLEANUP_DAYS", "7")),
+        help="Delete files older than this many days (default: env CLEANUP_DAYS or 7)",
+    )
+    args = parser.parse_args(argv)
+    removed = cleanup(Path(args.path), args.days)
+    print(f"Removed {removed} directories")
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry
+    main()

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "lego-gpt-backend"
-version = "0.5.19"
+version = "0.5.20"
 requires-python = ">=3.11"
 dependencies = [
     "redis>=5",
@@ -30,6 +30,7 @@ lego-gpt-worker = "backend.worker:main"
 lego-detect-worker = "detector.worker:main"
 lego-detect-train = "detector.train:main"
 lego-gpt-cli = "backend.cli:main"
+lego-gpt-cleanup = "backend.cleanup:main"
 
 [build-system]
 requires = ["setuptools>=64", "wheel"]

--- a/backend/tests/test_cleanup.py
+++ b/backend/tests/test_cleanup.py
@@ -1,0 +1,33 @@
+import os
+import sys
+import time
+import shutil
+import unittest
+from pathlib import Path
+
+project_root = Path(__file__).resolve().parents[2]
+if str(project_root) not in sys.path:
+    sys.path.insert(0, str(project_root))
+
+from backend.cleanup import cleanup
+
+
+class CleanupTests(unittest.TestCase):
+    def test_cleanup_removes_old_dirs(self):
+        base = Path("test-static")
+        base.mkdir(exist_ok=True)
+        old_d = base / "old"
+        new_d = base / "new"
+        old_d.mkdir()
+        new_d.mkdir()
+        old_time = time.time() - 2 * 86400
+        os.utime(old_d, (old_time, old_time))
+        removed = cleanup(base, days=1)
+        self.assertEqual(removed, 1)
+        self.assertFalse(old_d.exists())
+        self.assertTrue(new_d.exists())
+        shutil.rmtree(base)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -44,7 +44,7 @@ clusters not connected to the ground.
 | **API**       | Auth, rate-limit, CORS headers, enqueue job, expose static file links                                       | Python http.server stub |
 | **Worker**    | `lego-gpt-worker` runs `rq` jobs, lazy-loads LegoGPT, routes bricks → solver, saves PNG + LDR (use `--redis-url`, `--queue`, and `--version`) | Python 3.12, CUDA 12.2, HF `transformers` |
 | **Solver**    | Verify physical stability via MIP (connectivity, gravity, overhang)                           | OR-Tools / HiGHS |
-| **Storage**   | Serve artifacts locally or upload to S3 / Cloudflare R2                             | `/static` or S3 bucket |
+| **Storage**   | Serve artifacts locally or upload to S3 / Cloudflare R2                             | `/static` or S3 bucket; `lego-gpt-cleanup` removes old files |
 
 ---
 

--- a/docs/PROJECT_BACKLOG.md
+++ b/docs/PROJECT_BACKLOG.md
@@ -31,6 +31,7 @@
 | B-20 | **XS** | `lego-gpt-cli` command-line client    | **Done** | Python script to call the API |
 | B-21 | **XS** | CLI `--version` flag and tests        | **Done** | Unit tests cover the new flag |
 | B-22 | **XS** | `.env` configuration support          | **Done** | Load variables via python-dotenv |
+| B-23 | **XS** | Static asset cleanup script           | **Done** | `lego-gpt-cleanup` removes old assets |
 |------|-----|---------------------------------------|--------|-------|
 | S-10 | **M** | Introduce `ILPSolver` interface & refactor | **Done** | Branch `feature/solver-refactor` |
 | S-11 | **M** | Implement OR-Tools MIP constraints   | **Done** | Connectivity filter added; solver computes stable subset |
@@ -41,4 +42,4 @@
 * **Pri** – MoSCoW priority (**M**ust, **S**hould, **C**ould, **W**on’t-Have-Now).
 * **Status** – Open / WIP / Blocked / Done.
 
-_Last updated 2025-06-11_
+_Last updated 2025-06-12_

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "lego-gpt"
-version = "0.5.19"
+version = "0.5.20"
 requires-python = ">=3.11"
 
 [build-system]


### PR DESCRIPTION
## Summary
- add `lego-gpt-cleanup` utility and CLI entrypoint
- document cleanup script in README, architecture and backlog
- bump project version to 0.5.20
- provide `.env` fallback version in package
- add unit test for cleanup script

## Testing
- `python -m unittest discover -v`