### PR TITLE
Add token CLI and solver engine configuration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,6 +4,8 @@ REDIS_URL=redis://localhost:6379/0
 JWT_SECRET=changeme
 RATE_LIMIT=5
 STATIC_URL_PREFIX=/static
+# Solver backend (HIGHs or CBC)
+# ORTOOLS_ENGINE=HIGHs
 # Optional cleanup configuration
 # CLEANUP_DAYS=7
 # CLEANUP_DRY_RUN=0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [0.5.22] – 2025-06-14
+### Added
+* `lego-gpt-token` console script for JWT generation.
+* `ORTOOLS_ENGINE` env var and `--solver-engine` worker option.
+### Changed
+* Backend package version bumped to 0.5.22.
+
 ## [0.5.21] – 2025-06-13
 ### Added
 * `--dry-run` option for `lego-gpt-cleanup`.

--- a/README.md
+++ b/README.md
@@ -73,6 +73,8 @@ export REDIS_URL=redis://localhost:6379/0
 export QUEUE_NAME=legogpt
 lego-gpt-worker --redis-url "$REDIS_URL" --queue "$QUEUE_NAME" \
   --log-level INFO
+# Use a different solver backend with --solver-engine or ORTOOLS_ENGINE
+# lego-gpt-worker --solver-engine CBC
 # Launch the detector worker in another
 lego-detect-worker --redis-url "$REDIS_URL" --queue "$QUEUE_NAME" \
   --model detector/model.pt \
@@ -108,7 +110,7 @@ lego-gpt-server \
 # Set ``S3_BUCKET`` and optional ``S3_URL_PREFIX`` to upload assets to S3/R2.
 
 # Generate a JWT for requests
-python scripts/generate_jwt.py --secret mysecret --sub dev > token.txt
+lego-gpt-token --secret mysecret --sub dev > token.txt
 
 # Check the CLI version
 lego-gpt-cli --version

--- a/backend/__init__.py
+++ b/backend/__init__.py
@@ -22,7 +22,7 @@ except Exception:  # pragma: no cover - ignore if missing
 try:  # pragma: no cover - during editable installs
     __version__ = version("lego-gpt-backend")
 except PackageNotFoundError:  # pragma: no cover - fallback for tests
-    __version__ = "0.5.21"
+    __version__ = "0.5.22"
 
 PACKAGE_DIR = Path(__file__).parent
 _env_static = os.getenv("STATIC_ROOT")

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "lego-gpt-backend"
-version = "0.5.21"
+version = "0.5.22"
 requires-python = ">=3.11"
 dependencies = [
     "redis>=5",
@@ -31,6 +31,7 @@ lego-detect-worker = "detector.worker:main"
 lego-detect-train = "detector.train:main"
 lego-gpt-cli = "backend.cli:main"
 lego-gpt-cleanup = "backend.cleanup:main"
+lego-gpt-token = "backend.token_cli:main"
 
 [build-system]
 requires = ["setuptools>=64", "wheel"]

--- a/backend/solver/shim.py
+++ b/backend/solver/shim.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import importlib
 import json
+import os
 import sys
 from typing import Any, Tuple
 
@@ -16,7 +17,8 @@ from legogpt.data import LegoStructure
 from .ortools_solver import OrtoolsSolver
 
 try:  # Instantiate solver if OR-Tools is available
-    _solver = OrtoolsSolver()
+    backend_name = os.getenv("ORTOOLS_ENGINE", "HIGHs")
+    _solver = OrtoolsSolver(backend_name)
 except Exception:  # pragma: no cover - fallback to dummy score
     _solver = None
 

--- a/backend/tests/test_token_cli.py
+++ b/backend/tests/test_token_cli.py
@@ -1,0 +1,26 @@
+import io
+import sys
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+project_root = Path(__file__).resolve().parents[2]
+if str(project_root) not in sys.path:
+    sys.path.insert(0, str(project_root))
+
+import backend
+import backend.token_cli as token_cli
+
+
+class TokenCLITests(unittest.TestCase):
+    def test_generate_token_cli(self):
+        argv = ["token", "--secret", "s3", "--sub", "alice", "--exp", "60"]
+        with patch.object(sys, "argv", argv), patch("sys.stdout", new=io.StringIO()) as fake_out:
+            token_cli.main()
+            token = fake_out.getvalue().strip()
+        payload = backend.auth.decode(token, "s3")
+        self.assertEqual(payload["sub"], "alice")
+
+
+if __name__ == "__main__":  # pragma: no cover
+    unittest.main()

--- a/backend/tests/test_worker_cli.py
+++ b/backend/tests/test_worker_cli.py
@@ -28,11 +28,12 @@ class WorkerCLITests(unittest.TestCase):
             '--redis-url', 'redis://host:9999/1',
             '--queue', 'testq',
             '--log-level', 'DEBUG',
+            '--solver-engine', 'CBC',
         ]
         with patch.object(sys, 'argv', argv):
             with patch('backend.worker.run_worker') as mock_run:
                 worker.main()
-                mock_run.assert_called_once_with('redis://host:9999/1', 'testq', 'DEBUG')
+                mock_run.assert_called_once_with('redis://host:9999/1', 'testq', 'DEBUG', 'CBC')
 
     def test_detector_worker_version_flag(self):
         with patch.object(sys, 'argv', ['detector-worker', '--version']):

--- a/backend/token_cli.py
+++ b/backend/token_cli.py
@@ -1,0 +1,38 @@
+"""Console script to generate JWT tokens for the API."""
+from __future__ import annotations
+
+import argparse
+import os
+from datetime import datetime, timedelta
+
+from backend.auth import encode
+
+
+def generate_token(secret: str, sub: str, lifetime: int) -> str:
+    """Return a JWT token signed with ``secret``."""
+    exp_ts = int((datetime.utcnow() + timedelta(seconds=lifetime)).timestamp())
+    return encode({"sub": sub}, secret, exp=exp_ts)
+
+
+def main(argv: list[str] | None = None) -> None:
+    parser = argparse.ArgumentParser(description="Generate JWT token for Lego GPT API")
+    parser.add_argument(
+        "--secret",
+        "-s",
+        default=os.getenv("JWT_SECRET", "secret"),
+        help="HMAC secret (default: env JWT_SECRET or 'secret')",
+    )
+    parser.add_argument("--sub", default="dev", help="Subject claim (default: dev)")
+    parser.add_argument(
+        "--exp",
+        type=int,
+        default=3600,
+        help="Token lifetime in seconds (default: 3600)",
+    )
+    args = parser.parse_args(argv)
+    token = generate_token(args.secret, args.sub, args.exp)
+    print(token)
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry point
+    main()

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -65,6 +65,8 @@ clusters not connected to the ground.
 8. Set ``LOG_LEVEL`` or pass ``--log-level`` to server/workers to control logging verbosity.
 9. Environment variables can be placed in a ``.env`` file. If
    ``python-dotenv`` is installed, the backend loads it automatically on startup.
+10. Set ``ORTOOLS_ENGINE`` or pass ``--solver-engine`` to the worker to pick a
+    specific OR-Tools backend (``HIGHs`` or ``CBC``).
 
 ---
 

--- a/docs/PROJECT_BACKLOG.md
+++ b/docs/PROJECT_BACKLOG.md
@@ -38,9 +38,13 @@
 | S-11 | **M** | Implement OR-Tools MIP constraints   | **Done** | Connectivity filter added; solver computes stable subset |
 | S-12 | **S** | Solver auto-loader + unit tests      | **Done** | Part of solver refactor |
 | S-13 | **XS**| Update docs for solver swap          | **Done** | README & ARCHITECTURE |
+| B-25 | **XS** | JWT token CLI (`lego-gpt-token`) | **Done** | Generates auth tokens from the command line |
+| S-14 | **XS** | Configurable OR-Tools backend (`ORTOOLS_ENGINE`) | **Done** | Worker `--solver-engine` flag |
+
+
 
 ### Legend
 * **Pri** – MoSCoW priority (**M**ust, **S**hould, **C**ould, **W**on’t-Have-Now).
 * **Status** – Open / WIP / Blocked / Done.
 
-_Last updated 2025-06-13_
+_Last updated 2025-06-14_

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "lego-gpt"
-version = "0.5.21"
+version = "0.5.22"
 requires-python = ">=3.11"
 
 [build-system]


### PR DESCRIPTION
## Summary
- add `lego-gpt-token` console script for easy JWT creation
- allow selecting OR-Tools backend via `ORTOOLS_ENGINE`/`--solver-engine`
- document new CLI, env var and update project backlog
- bump version to 0.5.22

## Testing
- `./scripts/run_tests.sh`