### PR TITLE
Add inventory option & dotenv support to CLI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,15 @@
+## [0.5.24] – 2025-06-15
+### Added
+* `.env` loading for `lego-gpt-cli`.
+### Changed
+* Backend package version bumped to 0.5.24.
+
+## [0.5.23] – 2025-06-15
+### Added
+* `--inventory` option for `lego-gpt-cli` to send brick counts.
+### Changed
+* Backend package version bumped to 0.5.23.
+
 ## [0.5.22] – 2025-06-14
 ### Added
 * `lego-gpt-token` console script for JWT generation.

--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ real-life building via a built-in Three.js viewer.
 | 🔗 **Static URL prefix** configurable | Set `STATIC_URL_PREFIX` to point asset links at a CDN |
 | ☁️ **S3/R2 uploads** | Set `S3_BUCKET` and `S3_URL_PREFIX` to host assets in the cloud |
 | 🆕 **CLI `--version` flag + tests** | `lego-gpt-cli --version` shows backend version; automated tests ensure it works |
+| 🆕 **`--inventory` & `.env` support** | CLI loads env vars from `.env` and accepts `--inventory` JSON |
 | 🧹 **Cleanup script** (`lego-gpt-cleanup`) | Remove old asset directories (use `--dry-run` to preview) |
 
 &nbsp;
@@ -117,6 +118,9 @@ lego-gpt-cli --version
 
 # Test the API via the command-line client
 lego-gpt-cli --token $(cat token.txt) generate "a red car"
+# Pass a brick inventory JSON file
+lego-gpt-cli --token $(cat token.txt) generate "a red car" --inventory my_inv.json
+# The CLI loads API_URL and JWT from a .env file if present
 
 # Start the front-end PWA
 pnpm --dir frontend run dev    # http://localhost:5173

--- a/backend/__init__.py
+++ b/backend/__init__.py
@@ -22,7 +22,7 @@ except Exception:  # pragma: no cover - ignore if missing
 try:  # pragma: no cover - during editable installs
     __version__ = version("lego-gpt-backend")
 except PackageNotFoundError:  # pragma: no cover - fallback for tests
-    __version__ = "0.5.22"
+    __version__ = "0.5.24"
 
 PACKAGE_DIR = Path(__file__).parent
 _env_static = os.getenv("STATIC_ROOT")

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "lego-gpt-backend"
-version = "0.5.22"
+version = "0.5.24"
 requires-python = ">=3.11"
 dependencies = [
     "redis>=5",

--- a/backend/tests/test_cli_dotenv.py
+++ b/backend/tests/test_cli_dotenv.py
@@ -1,0 +1,43 @@
+import importlib
+import io
+import os
+import sys
+import tempfile
+from pathlib import Path
+from unittest.mock import patch
+import unittest
+
+project_root = Path(__file__).resolve().parents[2]
+vendor_root = project_root / "vendor"
+for p in (project_root, vendor_root):
+    if str(p) not in sys.path:
+        sys.path.insert(0, str(p))
+
+import backend.cli as cli
+
+
+class CLIDotEnvTests(unittest.TestCase):
+    def test_cli_loads_dotenv(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            env = Path(tmpdir) / ".env"
+            env.write_text("API_URL=http://x\nJWT=tok\n")
+            cwd = os.getcwd()
+            try:
+                os.chdir(tmpdir)
+                importlib.reload(cli)
+                argv = ["cli", "generate", "hi"]
+                with patch.object(sys, "argv", argv), \
+                     patch("backend.cli._post", return_value={"job_id": "1"}) as mock_post, \
+                     patch("backend.cli._poll", return_value={"ok": True}), \
+                     patch("sys.stdout", new=io.StringIO()):
+                    cli.main()
+                mock_post.assert_called_once()
+                self.assertEqual(mock_post.call_args[0][0], "http://x/generate")
+                self.assertEqual(mock_post.call_args[0][1], "tok")
+            finally:
+                os.chdir(cwd)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    unittest.main()
+

--- a/docs/PROJECT_BACKLOG.md
+++ b/docs/PROJECT_BACKLOG.md
@@ -39,6 +39,8 @@
 | S-12 | **S** | Solver auto-loader + unit tests      | **Done** | Part of solver refactor |
 | S-13 | **XS**| Update docs for solver swap          | **Done** | README & ARCHITECTURE |
 | B-25 | **XS** | JWT token CLI (`lego-gpt-token`) | **Done** | Generates auth tokens from the command line |
+| B-26 | **XS** | CLI `--inventory` option | **Done** | Supply brick counts via JSON file |
+| B-27 | **XS** | CLI loads `.env` | **Done** | `API_URL` and `JWT` automatically read |
 | S-14 | **XS** | Configurable OR-Tools backend (`ORTOOLS_ENGINE`) | **Done** | Worker `--solver-engine` flag |
 
 
@@ -47,4 +49,4 @@
 * **Pri** – MoSCoW priority (**M**ust, **S**hould, **C**ould, **W**on’t-Have-Now).
 * **Status** – Open / WIP / Blocked / Done.
 
-_Last updated 2025-06-14_
+_Last updated 2025-06-15_

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "lego-gpt"
-version = "0.5.22"
+version = "0.5.24"
 requires-python = ">=3.11"
 
 [build-system]


### PR DESCRIPTION
## Summary
- allow `lego-gpt-cli` to read `.env` on startup
- add `--inventory` option to send brick counts
- document CLI changes in README
- update project backlog
- bump version to 0.5.24
- update changelog
- add unit tests for new CLI features

## Testing
- `ruff check backend detector`
- `python -m pytest -q`