### PR TITLE
Add redis to compose and bump version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [0.5.28] – 2025-06-17
+### Added
+* Redis service in `docker-compose.yml`.
+### Changed
+* Backend package version bumped to 0.5.28.
+
 ## [0.5.27] – 2025-06-16
 ### Added
 * Front-end `VITE_API_URL` configuration with example env file.

--- a/README.md
+++ b/README.md
@@ -167,7 +167,7 @@ dependencies so the stack works out‑of‑the‑box:
 docker compose up --build
 ```
 
-This spins up the API server, a generation worker and the detector worker.
+This spins up Redis, the API server, a generation worker and the detector worker.
 
 The API will be available at http://localhost:8000/health.
 The `/health` endpoint responds with `{ "ok": true, "version": "x.y.z" }` so you

--- a/backend/__init__.py
+++ b/backend/__init__.py
@@ -22,7 +22,7 @@ except Exception:  # pragma: no cover - ignore if missing
 try:  # pragma: no cover - during editable installs
     __version__ = version("lego-gpt-backend")
 except PackageNotFoundError:  # pragma: no cover - fallback for tests
-    __version__ = "0.5.27"
+    __version__ = "0.5.28"
 
 PACKAGE_DIR = Path(__file__).parent
 _env_static = os.getenv("STATIC_ROOT")

--- a/backend/docker-compose.yml
+++ b/backend/docker-compose.yml
@@ -1,6 +1,10 @@
 version: "3.9"
 
 services:
+  redis:
+    image: redis:7
+    ports:
+      - "6379:6379"
   api:
     build:
       context: .

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "lego-gpt-backend"
-version = "0.5.27"
+version = "0.5.28"
 requires-python = ">=3.11"
 dependencies = [
     "redis>=5",

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,8 @@
 services:
+  redis:
+    image: redis:7
+    ports:
+      - "6379:6379"
   api:
     build:
       # Build from repo root so the vendored `legogpt/` package is included

--- a/docs/PROJECT_BACKLOG.md
+++ b/docs/PROJECT_BACKLOG.md
@@ -46,7 +46,7 @@
 | B-29 | **XS** | Configurable API base URL in front-end (`VITE_API_URL`) | **Done** | `.env.example` added |
 | B-30 | **XS** | CLI `generate` downloads assets via `--out-dir` | **Done** | Saves PNG/ldr/gltf locally |
 | S-15 | **XS** | Log to file via `--log-file` / `LOG_FILE` | **Done** | Server & workers support file logging |
-| D-21 | **M**  | Add Redis service to docker-compose                     | **Open** | `docker compose up` starts all services without extra steps. |
+| D-21 | **M**  | Add Redis service to docker-compose                     | **Done** | `docker compose up` starts all services without extra steps. |
 | A-18 | **S**  | Expose FastAPI router (or rename gateway)               | **Open** | Surface `APIRouter` in `backend/api.py` or rename file; update docs. |
 | S-09 | **S**  | JWT secret rotation & path-traversal tests               | **Open** | Document rotation process; add unit tests for `../` escapes. |
 | Q-04 | **S**  | Coverage reporting & badges                             | **Open** | Add pytest-cov workflow, upload to Codecov, show badge (≥80%). |
@@ -60,4 +60,4 @@
 * **Pri** – MoSCoW priority (**M**ust, **S**hould, **C**ould, **W**on’t-Have-Now).
 * **Status** – Open / WIP / Blocked / Done.
 
-_Last updated 2025-06-16_
+_Last updated 2025-06-17_

--- a/docs/SPRINT_PLAN.md
+++ b/docs/SPRINT_PLAN.md
@@ -1,0 +1,22 @@
+# Sprint Plan
+
+This document outlines the next five logical sprints for the project.
+
+## Sprint 1 – Docker Compose Redis service (completed)
+* Add a `redis` service to `docker-compose.yml` and `backend/docker-compose.yml`.
+* Update README instructions and mark backlog item D‑21 as **Done**.
+
+## Sprint 2 – Expose FastAPI router
+* Surface a reusable `APIRouter` in `backend/api.py` or rename `server.py` to clarify that it acts as the gateway.
+* Update documentation accordingly.
+
+## Sprint 3 – JWT secret rotation & path traversal tests
+* Document token rotation procedure.
+* Add unit tests ensuring the static file handler rejects `../` escapes.
+
+## Sprint 4 – Coverage reporting
+* Integrate `pytest-cov` in the test workflow.
+* Upload coverage to Codecov and show a badge in the README.
+
+## Sprint 5 – Version & changelog automation
+* Add a release workflow that bumps the version and updates the changelog on tags.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "lego-gpt"
-version = "0.5.27"
+version = "0.5.28"
 requires-python = ">=3.11"
 
 [build-system]


### PR DESCRIPTION
## Summary
- spin up Redis service alongside backend containers
- bump version numbers to 0.5.28
- update README docker-compose section
- mark backlog item D-21 done and document upcoming sprints

## Testing
- `ruff check backend detector`
- `python -m unittest discover -v`
