### PR TITLE
Improve offline setup handling

### DIFF
--- a/.codex/setup.sh
+++ b/.codex/setup.sh
@@ -14,7 +14,5 @@ python -m pip install --no-cache-dir -e ./backend[test] || \
 corepack enable
 corepack prepare pnpm@10.5.2 --activate
 
-# Pre-fetch front-end packages while network access is available
-pnpm fetch --prod=false --dir frontend
-# Install using the cached packages once network access is removed
-pnpm install --offline --dir frontend
+# Install front-end dependencies (uses cached packages when offline)
+./scripts/setup_frontend.sh

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [0.5.33] – 2025-06-20
+### Changed
+* `.codex/setup.sh` now calls `scripts/setup_frontend.sh` to handle offline installs.
+
 ## [0.5.32] – 2025-05-25
 ### Added
 * Offline mode improvements: IndexedDB caching for API responses.

--- a/README.md
+++ b/README.md
@@ -64,6 +64,8 @@ npm install -g pnpm@10.5.2
 # Add the `[env]` extra to enable `.env` configuration support
 python -m pip install --editable ./backend[test,env]
 # The dev container's setup script runs this automatically.
+# `.codex/setup.sh` calls `scripts/setup_frontend.sh` during container setup.
+# This only works offline if the pnpm store was populated once while online.
 
 # Start Redis (local or Docker)
 # docker run -p 6379:6379 -d redis:7


### PR DESCRIPTION
## Summary
- invoke `scripts/setup_frontend.sh` from `.codex/setup.sh`
- document the dependency caching requirement in README
- note setup script change in CHANGELOG

## Testing
- `pnpm --dir frontend run lint`
- `bash .codex/setup.sh`
- `python -m unittest discover -v`