### PR TITLE
Improve offline lint docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [0.5.33] – 2025-05-26
+### Changed
+* Documentation clarifies offline front-end lint behavior.
+* Backend package version bumped to 0.5.33.
+
 ## [0.5.32] – 2025-05-25
 ### Added
 * Offline mode improvements: IndexedDB caching for API responses.

--- a/README.md
+++ b/README.md
@@ -56,8 +56,8 @@ npm install -g pnpm@10.5.2
 # Install front-end dependencies.
 # The script installs from the local pnpm store if possible and fetches from
 # the registry when online. Run it once with network access.
-# Running it offline before the store is populated will print instructions
-# to retry with network access. The script requires `pnpm` to be installed.
+# Running it offline before the store is populated prints a brief message and
+# skips linting. The script requires `pnpm` to be installed.
 ./scripts/setup_frontend.sh
 
 # Install backend dependencies and dev tools (includes `ruff` for linting)

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "lego-gpt-backend"
-version = "0.5.32"
+version = "0.5.33"
 requires-python = ">=3.11"
 dependencies = [
     "redis>=5",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "lego-gpt"
-version = "0.5.32"
+version = "0.5.33"
 requires-python = ">=3.11"
 
 [build-system]


### PR DESCRIPTION
## Summary
- document offline lint message behavior
- bump backend version to 0.5.33

## Testing
- `ruff check backend detector`
- `python -m unittest discover -v`
