### PR TITLE
Fix lockfile after merge

### DIFF
--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -14,6 +14,9 @@ importers:
       react-dom:
         specifier: ^19.1.0
         version: 19.1.0(react@19.1.0)
+      react-router-dom:
+        specifier: ^6.23.0
+        version: 6.23.0(react@19.1.0)
     devDependencies:
       '@eslint/js':
         specifier: ^9.25.0
@@ -2469,6 +2472,20 @@ snapshots:
     dependencies:
       react: 19.1.0
       scheduler: 0.26.0
+
+  react-router@6.23.0(react@19.1.0):
+    dependencies:
+      '@remix-run/router': 1.10.0
+      react: 19.1.0
+
+  react-router-dom@6.23.0(react@19.1.0):
+    dependencies:
+      '@remix-run/router': 1.10.0
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
+      react-router: 6.23.0(react@19.1.0)
+
+  '@remix-run/router@1.10.0': {}
 
   react-refresh@0.17.0: {}
 


### PR DESCRIPTION
## Summary
- add `react-router-dom` to pnpm lockfile
- include entries for its dependencies

## Testing
- `./scripts/run_tests.sh`