### PR TITLE
Fix offline frontend lint skip

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [0.5.39] – 2025-06-24
+### Changed
+* `lint_frontend.js` no longer tries to install packages offline; it simply
+  prints a brief message when dependencies are missing.
+
 ## [0.5.38] – 2025-06-23
 ### Added
 * Install prompt and touch-friendly viewer.

--- a/scripts/lint_frontend.js
+++ b/scripts/lint_frontend.js
@@ -10,16 +10,8 @@ process.chdir(frontendDir);
 
 const eslintBin = join('node_modules', '.bin', 'eslint');
 if (!existsSync(eslintBin)) {
-  try {
-    execSync('pnpm install --offline', { stdio: 'inherit' });
-  } catch {
-    console.error('Front-end dependencies missing. Run scripts/setup_frontend.sh with network access.');
-    process.exit(0);
-  }
-  if (!existsSync(eslintBin)) {
-    console.error('Front-end dependencies missing. Run scripts/setup_frontend.sh with network access.');
-    process.exit(0);
-  }
+  console.error('Front-end dependencies missing. Run scripts/setup_frontend.sh with network access.');
+  process.exit(0);
 }
 
 try {


### PR DESCRIPTION
## Summary
- avoid pnpm error noise when frontend deps are missing
- note change in CHANGELOG

## Testing
- `./scripts/run_tests.sh`