### PR TITLE
Fix CI benchmark and use timezone-aware JWT

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,3 +9,7 @@ STATIC_URL_PREFIX=/static
 # Optional cleanup configuration
 # CLEANUP_DAYS=7
 # CLEANUP_DRY_RUN=0
+# Terraform examples
+# TF_VAR_docker_image=ghcr.io/<owner>/lego-gpt:latest
+# TF_VAR_jwt_secret=changeme
+

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,11 +21,13 @@ jobs:
         with:
           python-version: "3.12"
 
-      - name: Install ruff and coverage
-        run: pip install ruff coverage
+      - name: Install ruff, coverage and project deps
+        run: |
+          pip install ruff coverage
+          pip install -e ./backend[test,env]
 
       - name: Run ruff
-        run: ruff check backend detector
+        run: ruff check backend detector scripts
 
       - name: Run tests with coverage
         run: |
@@ -50,6 +52,37 @@ jobs:
 
       - name: Run front-end lint
         run: pnpm --dir frontend run lint
+
+      - name: Start Redis
+        run: docker run -d -p 6379:6379 --name redis redis:7
+
+      - name: Start API server
+        env:
+          JWT_SECRET: benchmark
+        run: |
+          python backend/gateway.py --jwt-secret $JWT_SECRET &
+          echo $! > server.pid
+
+      - name: Start worker
+        env:
+          JWT_SECRET: benchmark
+        run: |
+          python backend/worker.py --redis-url redis://localhost:6379/0 &
+          echo $! > worker.pid
+
+      - name: Run scalability benchmark
+        run: |
+          sleep 5
+          token=$(python scripts/generate_jwt.py --secret benchmark --exp 60)
+          python scripts/benchmark_scalability.py --token $token --requests 4 --concurrency 2
+
+      - name: Stop services
+        if: always()
+        run: |
+          kill $(cat server.pid) || true
+          kill $(cat worker.pid) || true
+          docker stop redis
+          docker rm redis
       # 6. (Optional) Build dev Docker image
       # - name: Build Docker image
       #   run: docker build -f Dockerfile.dev -t lego-gpt-dev .

--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,10 @@ backend/static/
 # Local environment
 .env
 
+
+# Terraform
+*.tfstate
+*.tfstate.*
+.terraform/
+terraform.tfvars
+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,18 @@
+## [0.5.41] – 2025-06-25
+### Added
+* CI now installs backend dependencies before running scalability tests.
+### Changed
+* `generate_jwt.py` and `token_cli.py` use timezone-aware datetimes.
+* Backend package version bumped to 0.5.41.
+
+## [0.5.40] – 2025-06-25
+### Added
+* Terraform templates for AWS, GCP and Azure.
+* CI step runs scalability benchmark.
+* Deployment guide and sprint plan archive.
+### Changed
+* Backend package version bumped to 0.5.40.
+
 ## [0.5.39] – 2025-06-24
 ### Changed
 * `lint_frontend.js` no longer tries to install packages offline; it simply

--- a/README.md
+++ b/README.md
@@ -194,15 +194,18 @@ Release tags trigger a workflow that builds CPU and GPU images and publishes
 them to GitHub Container Registry.  You can pull the latest versioned images:
 
 ```bash
-docker pull ghcr.io/<owner>/lego-gpt:v0.5.38        # CPU
-docker pull ghcr.io/<owner>/lego-gpt:gpu-v0.5.38    # GPU
+docker pull ghcr.io/<owner>/lego-gpt:v0.5.40        # CPU
+docker pull ghcr.io/<owner>/lego-gpt:gpu-v0.5.40    # GPU
 ```
 
 Run the API server with:
 
 ```bash
-docker run -p 8000:8000 ghcr.io/<owner>/lego-gpt:v0.5.38
+docker run -p 8000:8000 ghcr.io/<owner>/lego-gpt:v0.5.40
 ```
+
+### Deployment Guide
+For production deployment and Terraform samples see [docs/DEPLOYMENT.md](docs/DEPLOYMENT.md).
 
 Override the command to start a worker or the detector worker as needed.
 
@@ -246,6 +249,7 @@ detector/           Brick-detector micro-service worker
 docker-compose.yml  Dev stack (server + workers)
 ```
 
+Example prompts and builds live under `examples/`.
 &nbsp;
 
 ## 5. API Contract

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "lego-gpt-backend"
-version = "0.5.38"
+version = "0.5.41"
 requires-python = ">=3.11"
 dependencies = [
     "redis>=5",

--- a/backend/token_cli.py
+++ b/backend/token_cli.py
@@ -3,14 +3,14 @@ from __future__ import annotations
 
 import argparse
 import os
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 
 from backend.auth import encode
 
 
 def generate_token(secret: str, sub: str, lifetime: int) -> str:
     """Return a JWT token signed with ``secret``."""
-    exp_ts = int((datetime.utcnow() + timedelta(seconds=lifetime)).timestamp())
+    exp_ts = int((datetime.now(timezone.utc) + timedelta(seconds=lifetime)).timestamp())
     return encode({"sub": sub}, secret, exp=exp_ts)
 
 

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -1,0 +1,33 @@
+# Deployment Guide
+
+This document explains how to deploy Lego GPT in production.
+
+## Docker Compose
+
+The simplest way to run the stack is via Docker Compose:
+
+```bash
+docker compose up --build -d
+```
+
+This launches Redis, the API gateway and both worker processes.  Configure secrets in a `.env` file or pass them via the environment.
+
+## Terraform
+
+Sample Terraform templates live in `infrastructure/terraform`. Copy the directory for your cloud provider and set variables via `TF_VAR_` environment variables:
+
+```bash
+export TF_VAR_jwt_secret=$(openssl rand -hex 32)
+export TF_VAR_docker_image=ghcr.io/<owner>/lego-gpt:v0.5.40
+```
+
+Run `terraform init` followed by `terraform apply` to provision the resources.
+
+Keep secrets out of source control by relying on environment variables or dedicated secret stores.
+
+## Best Practices
+
+* Rotate the `JWT_SECRET` periodically (`docs/TOKEN_ROTATION.md`).
+* Use HTTPS and restrict network access to Redis.
+* Monitor worker logs and set up alerts for failed jobs.
+* Benchmark changes regularly to catch performance regressions.

--- a/docs/PROJECT_BACKLOG.md
+++ b/docs/PROJECT_BACKLOG.md
@@ -59,6 +59,7 @@
 | D-22 | **S**  | Deployment automation (CPU & GPU images)               | **Done** | Release workflow builds and pushes Docker images |
 | D-23 | **S**  | Scalability benchmarking                              | **Done** | Benchmark script and tuning docs |
 | F-08 | **C**  | Advanced front-end features                            | **Done** | Offline queue + settings page |
+| D-24 | **S**  | Cloud infrastructure templates                      | **Done** | Terraform samples for AWS, GCP and Azure |
 
 
 
@@ -66,4 +67,4 @@
 * **Pri** – MoSCoW priority (**M**ust, **S**hould, **C**ould, **W**on’t-Have-Now).
 * **Status** – Open / WIP / Blocked / Done.
 
-_Last updated 2025-06-22_
+_Last updated 2025-06-25_

--- a/docs/SPRINT_PLAN_ARCHIVE.md
+++ b/docs/SPRINT_PLAN_ARCHIVE.md
@@ -1,0 +1,14 @@
+# Sprint Plan Archive
+
+Older sprint plans are kept here for reference.
+
+- `SPRINT_PLAN.md`
+- `SPRINT_PLAN_NEXT.md`
+- `SPRINT_PLAN_NEW.md`
+- `SPRINT_PLAN_NEXT_STEPS.md`
+- `SPRINT_PLAN_FUTURE.md`
+- `SPRINT_PLAN_POST_AUTOMATION.md`
+- `SPRINT_PLAN_FOLLOWUP.md`
+- `SPRINT_PLAN_NEXT_ROUND.md`
+
+The latest roadmap lives in `SPRINT_PLAN_LATEST.md`.

--- a/docs/SPRINT_PLAN_LATEST.md
+++ b/docs/SPRINT_PLAN_LATEST.md
@@ -1,8 +1,9 @@
 # Latest Sprint Plan
 
 This plan outlines the next five logical sprints after completing the advanced front-end features.
+Older plans have moved to `SPRINT_PLAN_ARCHIVE.md`.
 
-## Sprint 1 – Cloud infrastructure templates
+## Sprint 1 – Cloud infrastructure templates (completed)
 * Provide Terraform samples for common cloud providers.
 * Offer environment variables for secret management.
 
@@ -10,12 +11,12 @@ This plan outlines the next five logical sprints after completing the advanced f
 * Fine‑tune touch controls in the 3‑D viewer.
 * Add install prompts and home-screen icons.
 
-## Sprint 3 – Documentation cleanup
+## Sprint 3 – Documentation cleanup (completed)
 * Consolidate older sprint plans.
 * Expand deployment instructions with best practices.
 
-## Sprint 4 – Continuous benchmarking
+## Sprint 4 – Continuous benchmarking (completed)
 * Automate the scalability benchmark in CI for regressions.
 
-## Sprint 5 – Community example library
+## Sprint 5 – Community example library (in progress)
 * Curate a gallery of example builds and shareable prompts.

--- a/docs/SPRINT_PLAN_NEXT_GEN.md
+++ b/docs/SPRINT_PLAN_NEXT_GEN.md
@@ -1,0 +1,21 @@
+# Next Sprint Plan
+
+With the infrastructure and documentation work complete, development can move toward enhanced usability and community engagement.
+
+## Sprint 1 – Security scanning
+* Integrate a dependency vulnerability scanner into CI.
+* Document a responsible disclosure process.
+
+## Sprint 2 – Kubernetes deployment
+* Provide Helm charts for deploying the stack on Kubernetes clusters.
+* Include secrets configuration via Kubernetes secrets.
+
+## Sprint 3 – Localization support
+* Add i18n framework to the front-end.
+* Provide an initial Spanish translation.
+
+## Sprint 4 – Automated release notes
+* Generate changelog entries from commit history during the release workflow.
+
+## Sprint 5 – Chatbot integration
+* Expose the API via a simple Slack or Discord bot example.

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,9 @@
+# Community Example Library
+
+Contribute your favourite Lego GPT builds here. Add a folder with a short name and include:
+
+* `prompt.txt` – the text prompt used for generation
+* `preview.png` – screenshot of the result (optional)
+* `model.ldr` – the LDraw file
+
+Submissions are welcome via pull request.

--- a/infrastructure/terraform/README.md
+++ b/infrastructure/terraform/README.md
@@ -1,0 +1,19 @@
+# Terraform Templates
+
+Sample Terraform configurations for deploying Lego GPT on various cloud providers.
+These templates are intentionally minimal and use environment variables for sensitive values.
+Copy the appropriate directory, set the required variables, and run `terraform init && terraform apply`.
+
+## Secrets via Environment Variables
+Terraform automatically picks up variables prefixed with `TF_VAR_`.
+Export the following before applying the plan:
+
+```bash
+export TF_VAR_jwt_secret=mysecret
+export TF_VAR_docker_image=ghcr.io/<owner>/lego-gpt:latest
+# Provider credentials
+export AWS_ACCESS_KEY_ID=...
+export AWS_SECRET_ACCESS_KEY=...
+```
+
+Refer to each provider directory for details.

--- a/infrastructure/terraform/aws/main.tf
+++ b/infrastructure/terraform/aws/main.tf
@@ -1,0 +1,21 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+}
+
+provider "aws" {
+  region     = var.region
+}
+
+resource "aws_instance" "lego_gpt" {
+  ami           = var.ami
+  instance_type = "t3.micro"
+  user_data     = templatefile("${path.module}/user-data.sh", {
+    image      = var.docker_image
+    jwt_secret = var.jwt_secret
+  })
+}

--- a/infrastructure/terraform/aws/user-data.sh
+++ b/infrastructure/terraform/aws/user-data.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+# Install Docker if missing
+if ! command -v docker >/dev/null; then
+  apt-get update && apt-get install -y docker.io
+fi
+# Run Lego GPT container
+docker run -d -p 8000:8000 \
+  -e JWT_SECRET=${jwt_secret} \
+  ${image}

--- a/infrastructure/terraform/aws/variables.tf
+++ b/infrastructure/terraform/aws/variables.tf
@@ -1,0 +1,16 @@
+variable "region" {
+  description = "AWS region"
+}
+
+variable "ami" {
+  description = "AMI ID for the instance"
+}
+
+variable "docker_image" {
+  description = "Lego GPT Docker image"
+}
+
+variable "jwt_secret" {
+  description = "JWT secret passed to the container"
+  sensitive   = true
+}

--- a/infrastructure/terraform/azure/main.tf
+++ b/infrastructure/terraform/azure/main.tf
@@ -1,0 +1,39 @@
+terraform {
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = "~> 3.0"
+    }
+  }
+}
+
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "lego_gpt" {
+  name     = "lego-gpt-rg"
+  location = var.location
+}
+
+resource "azurerm_container_group" "lego_gpt" {
+  name                = "lego-gpt"
+  location            = azurerm_resource_group.lego_gpt.location
+  resource_group_name = azurerm_resource_group.lego_gpt.name
+  os_type             = "Linux"
+  ip_address_type     = "public"
+
+  container {
+    name   = "lego-gpt"
+    image  = var.docker_image
+    cpu    = "1"
+    memory = "1.5"
+    ports {
+      port     = 8000
+      protocol = "TCP"
+    }
+    environment_variables = {
+      JWT_SECRET = var.jwt_secret
+    }
+  }
+}

--- a/infrastructure/terraform/azure/variables.tf
+++ b/infrastructure/terraform/azure/variables.tf
@@ -1,0 +1,12 @@
+variable "location" {
+  description = "Azure region"
+}
+
+variable "docker_image" {
+  description = "Lego GPT Docker image"
+}
+
+variable "jwt_secret" {
+  description = "JWT secret passed to the container"
+  sensitive   = true
+}

--- a/infrastructure/terraform/gcp/main.tf
+++ b/infrastructure/terraform/gcp/main.tf
@@ -1,0 +1,30 @@
+terraform {
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = "~> 5.0"
+    }
+  }
+}
+
+provider "google" {
+  project = var.project
+  region  = var.region
+}
+
+resource "google_compute_instance" "lego_gpt" {
+  name         = "lego-gpt"
+  machine_type = "e2-medium"
+  zone         = var.zone
+
+  boot_disk {
+    initialize_params {
+      image = var.image
+    }
+  }
+
+  metadata_startup_script = templatefile("${path.module}/startup.sh", {
+    image      = var.docker_image
+    jwt_secret = var.jwt_secret
+  })
+}

--- a/infrastructure/terraform/gcp/startup.sh
+++ b/infrastructure/terraform/gcp/startup.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+# Install Docker
+if ! command -v docker >/dev/null; then
+  apt-get update && apt-get install -y docker.io
+fi
+# Run container
+docker run -d -p 8000:8000 \
+  -e JWT_SECRET=${jwt_secret} \
+  ${image}

--- a/infrastructure/terraform/gcp/variables.tf
+++ b/infrastructure/terraform/gcp/variables.tf
@@ -1,0 +1,24 @@
+variable "project" {
+  description = "GCP project ID"
+}
+
+variable "region" {
+  description = "GCP region"
+}
+
+variable "zone" {
+  description = "GCP zone"
+}
+
+variable "image" {
+  description = "Base VM image"
+}
+
+variable "docker_image" {
+  description = "Lego GPT Docker image"
+}
+
+variable "jwt_secret" {
+  description = "JWT secret passed to the container"
+  sensitive   = true
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "lego-gpt"
-version = "0.5.38"
+version = "0.5.41"
 requires-python = ">=3.11"
 
 [build-system]

--- a/scripts/benchmark_scalability.py
+++ b/scripts/benchmark_scalability.py
@@ -11,7 +11,13 @@ from __future__ import annotations
 import argparse
 import concurrent.futures as futures
 import statistics
+import sys
 import time
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
 
 from backend import cli
 

--- a/scripts/generate_jwt.py
+++ b/scripts/generate_jwt.py
@@ -4,7 +4,7 @@
 import argparse
 import os
 import sys
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -30,7 +30,7 @@ def main() -> None:
         help="Token lifetime in seconds (default: 3600)",
     )
     args = parser.parse_args()
-    exp_ts = int((datetime.utcnow() + timedelta(seconds=args.exp)).timestamp())
+    exp_ts = int((datetime.now(timezone.utc) + timedelta(seconds=args.exp)).timestamp())
     token = encode({"sub": args.sub}, args.secret, exp=exp_ts)
     print(token)
 


### PR DESCRIPTION
## Summary
- install backend dependencies in CI before running scalability benchmark
- make JWT helper scripts timezone aware
- ensure scalability script resolves repo root for imports
- bump package version to 0.5.41

## Testing
- `ruff check backend detector scripts`
- `pytest -q`
