### PR TITLE
Add community example gallery

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ real-life building via a built-in Three.js viewer.
 | 🧹 **Cleanup script** (`lego-gpt-cleanup`) | Remove old asset directories (use `--dry-run` to preview) |
 | 🆕 **Offline queue + settings** | Requests made offline are queued and cached results can be cleared in the settings page |
 | 📱 **Install prompt & touch controls** | Add to Home Screen button and smoother mobile controls |
+| 🖼️ **Community example gallery** | Browse shared prompts and load them with one click |
 
 &nbsp;
 
@@ -146,6 +147,7 @@ pnpm --dir frontend run dev    # http://localhost:5173
 # The PWA caches generated models in IndexedDB and preview images via a
 # service worker so previously viewed results remain available offline.
 # Requests made while offline are queued and processed once connectivity returns.
+# Browse shared prompts in the Examples page and load them with one click.
 # Lint UI code (skips if dependencies are missing)
 pnpm --dir frontend run lint
 # Lint backend code

--- a/docs/PROJECT_BACKLOG.md
+++ b/docs/PROJECT_BACKLOG.md
@@ -59,6 +59,7 @@
 | D-22 | **S**  | Deployment automation (CPU & GPU images)               | **Done** | Release workflow builds and pushes Docker images |
 | D-23 | **S**  | Scalability benchmarking                              | **Done** | Benchmark script and tuning docs |
 | F-08 | **C**  | Advanced front-end features                            | **Done** | Offline queue + settings page |
+| F-09 | **C**  | Community example library                             | **Done** | Gallery of prompts and builds |
 | B-33 | **S**  | Cloud infrastructure templates                       | **Done** | Terraform sample for AWS App Runner |
 
 

--- a/docs/SPRINT_PLAN_LATEST.md
+++ b/docs/SPRINT_PLAN_LATEST.md
@@ -18,8 +18,8 @@ This plan outlines the next five logical sprints after completing the advanced f
 * Automate the scalability benchmark in CI for regressions.
 * Added a stub server benchmark step in CI.
 
-## Sprint 5 – Community example library
-* Curate a gallery of example builds and shareable prompts.
+## Sprint 5 – Community example library (completed)
+* Added a gallery of example builds and shareable prompts in the PWA.
 
 Older sprint plans were combined into `SPRINT_PLAN_ARCHIVE.md` as part of the
 documentation cleanup.

--- a/docs/SPRINT_PLAN_NEXT.md
+++ b/docs/SPRINT_PLAN_NEXT.md
@@ -1,19 +1,16 @@
 # Next Sprint Plan
 
-This plan outlines the upcoming sprints after completing the continuous benchmarking automation.
+This plan outlines the upcoming sprints after completing the community example library.
 
-## Sprint 1 – Community example library
-* Curate a gallery of example builds and shareable prompts.
-
-## Sprint 2 – Automated UI regression tests
+## Sprint 1 – Automated UI regression tests
 * Add Cypress tests for critical PWA flows.
 
-## Sprint 3 – Multi-language support
+## Sprint 2 – Multi-language support
 * Localise the front-end strings and add a language switcher.
 
-## Sprint 4 – Real-time collaboration
+## Sprint 3 – Real-time collaboration
 * Enable shared editing of builds via WebSocket.
 
-## Sprint 5 – Model quality improvements
+## Sprint 4 – Model quality improvements
 * Experiment with larger LegoGPT checkpoints and training data.
 

--- a/frontend/public/examples.json
+++ b/frontend/public/examples.json
@@ -1,0 +1,20 @@
+[
+  {
+    "id": "1",
+    "title": "Red Castle",
+    "prompt": "build a small red castle",
+    "image": "https://placehold.co/200x150?text=Red+Castle"
+  },
+  {
+    "id": "2",
+    "title": "Space Rover",
+    "prompt": "a four-wheeled space rover with antenna",
+    "image": "https://placehold.co/200x150?text=Space+Rover"
+  },
+  {
+    "id": "3",
+    "title": "Mini Pirate Ship",
+    "prompt": "mini pirate ship with black sails",
+    "image": "https://placehold.co/200x150?text=Pirate+Ship"
+  }
+]

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect, FormEvent, ChangeEvent } from "react";
+import Examples from "./Examples";
 
 interface BeforeInstallPromptEvent extends Event {
   prompt: () => Promise<void>;
@@ -11,7 +12,7 @@ import Settings from "./Settings";
 import { processPending } from "./lib/offlineQueue";
 
 export default function App() {
-  const [page, setPage] = useState<"main" | "settings">("main");
+  const [page, setPage] = useState<"main" | "settings" | "examples">("main");
   const [prompt, setPrompt] = useState("");
   const [seed, setSeed] = useState("");
   const [photo, setPhoto] = useState<string | null>(null);
@@ -85,6 +86,15 @@ export default function App() {
     return <Settings onBack={() => setPage("main")} />;
   }
 
+  if (page === "examples") {
+    return (
+      <Examples
+        onBack={() => setPage("main")}
+        onSelect={(p) => setPrompt(p)}
+      />
+    );
+  }
+
   return (
     <main className="p-6 max-w-xl mx-auto font-sans">
       <h1 className="text-2xl font-bold mb-4">Lego GPT Demo</h1>
@@ -101,6 +111,12 @@ export default function App() {
         onClick={() => setPage("settings")}
       >
         Settings
+      </button>
+      <button
+        className="text-sm underline mb-4 ml-4"
+        onClick={() => setPage("examples")}
+      >
+        Examples
       </button>
 
       <form onSubmit={handleSubmit} className="space-y-4">

--- a/frontend/src/Examples.tsx
+++ b/frontend/src/Examples.tsx
@@ -1,0 +1,52 @@
+import { useEffect, useState } from "react";
+
+interface Example {
+  id: string;
+  title: string;
+  prompt: string;
+  image: string;
+}
+
+export default function Examples({
+  onSelect,
+  onBack,
+}: {
+  onSelect: (prompt: string) => void;
+  onBack: () => void;
+}) {
+  const [examples, setExamples] = useState<Example[]>([]);
+
+  useEffect(() => {
+    fetch("/examples.json")
+      .then((res) => res.json())
+      .then((data) => setExamples(data as Example[]))
+      .catch(() => setExamples([]));
+  }, []);
+
+  return (
+    <main className="p-6 max-w-xl mx-auto font-sans">
+      <h1 className="text-2xl font-bold mb-4">Community Examples</h1>
+      <div className="space-y-4">
+        {examples.map((ex) => (
+          <div key={ex.id} className="border p-2 rounded">
+            <img src={ex.image} alt={ex.title} className="w-full h-auto mb-2" />
+            <h2 className="font-semibold">{ex.title}</h2>
+            <p className="text-sm mb-2">{ex.prompt}</p>
+            <button
+              className="bg-blue-600 text-white px-3 py-1 rounded"
+              onClick={() => {
+                onSelect(ex.prompt);
+                onBack();
+              }}
+            >
+              Use Prompt
+            </button>
+          </div>
+        ))}
+      </div>
+      <button className="mt-6 text-blue-600 underline" onClick={onBack}>
+        Back
+      </button>
+    </main>
+  );
+}


### PR DESCRIPTION
## Summary
- add a small examples dataset in the frontend
- implement `<Examples />` page with prompt picker
- link the page from the main app
- document new feature and mark sprint complete
- update sprint plans and backlog

## Testing
- `pnpm --dir frontend run lint`
- `ruff check backend detector`
- `python -m unittest discover -v`