### PR TITLE
Fix pnpm lockfile issue in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,7 +46,7 @@ jobs:
           version: 10.5.2
 
       - name: Install front-end dependencies
-        run: pnpm install --frozen-lockfile --dir frontend
+        run: pnpm install --no-frozen-lockfile --dir frontend
 
       - name: Run front-end lint
         run: pnpm --dir frontend run lint


### PR DESCRIPTION
## Summary
- adjust GitHub workflow to allow installing dependencies when `pnpm-lock.yaml` is out of sync

## Testing
- `ruff check backend detector`
- `python -m unittest discover -v`
