### PR TITLE
Implement Cypress e2e testing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,8 +20,11 @@ dist/
 node_modules/
 npm-debug.log*
 pnpm-debug.log*
-dist/
 coverage/
+
+# Cypress output
+frontend/cypress/screenshots/
+frontend/cypress/videos/
 
 # Test artefacts
 out/

--- a/README.md
+++ b/README.md
@@ -152,6 +152,8 @@ pnpm --dir frontend run dev    # http://localhost:5173
 pnpm --dir frontend run lint
 # Lint backend code
 ruff check backend detector
+# Run UI tests (requires the dev server on another terminal)
+pnpm --dir frontend run test:e2e
 # Remove assets older than 7 days (preview with --dry-run)
 lego-gpt-cleanup --days 7 --dry-run
 # Convert an existing .ldr model to glTF
@@ -168,6 +170,7 @@ Install hooks with `pre-commit install` to automatically run `ruff` on each
 commit. The configuration lives in `.pre-commit-config.yaml`.
 
 Run `./scripts/run_tests.sh` to lint and test in one step.
+The script runs Cypress UI tests if the dependencies are available.
 CI runs the same tests under `coverage` and uploads the report to Codecov.
 CI also executes a lightweight scalability benchmark via
 `scripts/benchmark_ci.py` to detect performance regressions.
@@ -339,10 +342,12 @@ Default rate limit is `5` generate requests per token per minute (configurable v
    `@eslint/js`, `@types/react`, `@types/react-dom`, `@vitejs/plugin-react`,
    `eslint`, `eslint-config-prettier`, `eslint-plugin-react-hooks`,
    `eslint-plugin-react-refresh`, `globals`, `prettier`, `typescript`,
-   `typescript-eslint` and `vite`. Running the setup script offline before the
+   `typescript-eslint`, `vite` and `cypress`. Running the setup script offline before the
    store is populated prints a short message explaining the missing packages.
    Run `pnpm --dir frontend run lint` after editing UI code; the command skips if
    dependencies are missing.
+   Run `pnpm --dir frontend run test:e2e` to execute Cypress tests when
+   the Vite dev server is running.
 4. Run `python -m unittest discover -v` before pushing. The test suite uses
    Python's built-in `unittest` module. `pytest` is optional and works too.
 5. Update `docs/CHANGELOG.md` after each merge to `main`.

--- a/docs/PROJECT_BACKLOG.md
+++ b/docs/PROJECT_BACKLOG.md
@@ -61,6 +61,7 @@
 | F-08 | **C**  | Advanced front-end features                            | **Done** | Offline queue + settings page |
 | F-09 | **C**  | Community example library                             | **Done** | Gallery of prompts and builds |
 | B-33 | **S**  | Cloud infrastructure templates                       | **Done** | Terraform sample for AWS App Runner |
+| B-34 | **S**  | Automated UI regression tests                        | **Done** | Cypress setup and basic PWA flow test |
 
 
 
@@ -68,4 +69,4 @@
 * **Pri** – MoSCoW priority (**M**ust, **S**hould, **C**ould, **W**on’t-Have-Now).
 * **Status** – Open / WIP / Blocked / Done.
 
-_Last updated 2025-06-23_
+_Last updated 2025-06-30_

--- a/docs/SPRINT_PLAN_LATEST.md
+++ b/docs/SPRINT_PLAN_LATEST.md
@@ -21,5 +21,8 @@ This plan outlines the next five logical sprints after completing the advanced f
 ## Sprint 5 – Community example library (completed)
 * Added a gallery of example builds and shareable prompts in the PWA.
 
+## Sprint 6 – Automated UI regression tests (completed)
+* Added Cypress setup and a basic end-to-end test for the PWA.
+
 Older sprint plans were combined into `SPRINT_PLAN_ARCHIVE.md` as part of the
 documentation cleanup.

--- a/docs/SPRINT_PLAN_NEXT.md
+++ b/docs/SPRINT_PLAN_NEXT.md
@@ -2,15 +2,12 @@
 
 This plan outlines the upcoming sprints after completing the community example library.
 
-## Sprint 1 – Automated UI regression tests
-* Add Cypress tests for critical PWA flows.
-
-## Sprint 2 – Multi-language support
+## Sprint 1 – Multi-language support
 * Localise the front-end strings and add a language switcher.
 
-## Sprint 3 – Real-time collaboration
+## Sprint 2 – Real-time collaboration
 * Enable shared editing of builds via WebSocket.
 
-## Sprint 4 – Model quality improvements
+## Sprint 3 – Model quality improvements
 * Experiment with larger LegoGPT checkpoints and training data.
 

--- a/frontend/cypress.config.ts
+++ b/frontend/cypress.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from "cypress";
+
+export default defineConfig({
+  e2e: {
+    baseUrl: "http://localhost:5173",
+    supportFile: false,
+  },
+});

--- a/frontend/cypress/e2e/app.cy.ts
+++ b/frontend/cypress/e2e/app.cy.ts
@@ -1,0 +1,14 @@
+describe('Lego GPT PWA', () => {
+  it('loads the home page', () => {
+    cy.visit('/');
+    cy.contains('Lego GPT Demo');
+  });
+
+  it('submits a generate request', () => {
+    cy.intercept('POST', '/generate', { job_id: '1' }).as('generate');
+    cy.visit('/');
+    cy.get('input[required]').type('a house');
+    cy.get('button[type="submit"]').click();
+    cy.wait('@generate');
+  });
+});

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -8,7 +8,8 @@
     "build": "tsc -b && vite build",
     "lint": "node ../scripts/lint_frontend.js",
     "preview": "vite preview",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "test:e2e": "cypress run"
   },
   "dependencies": {
     "react": "^19.1.0",
@@ -27,7 +28,8 @@
     "prettier": "^3.5.3",
     "typescript": "~5.8.3",
     "typescript-eslint": "^8.30.1",
-    "vite": "^6.3.5"
+    "vite": "^6.3.5",
+    "cypress": "^13.7.3"
   },
   "packageManager": "pnpm@10.5.2"
 }

--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -2,3 +2,8 @@
 set -euo pipefail
 ruff check backend detector
 python -m pytest -q
+if [ -x frontend/node_modules/.bin/cypress ]; then
+  pnpm --dir frontend exec cypress run
+else
+  echo "Cypress not installed; skipping UI tests." >&2
+fi

--- a/scripts/setup_frontend.sh
+++ b/scripts/setup_frontend.sh
@@ -25,6 +25,7 @@ PKGS=(
   typescript
   typescript-eslint
   vite
+  cypress
 )
 set -euo pipefail
 


### PR DESCRIPTION
## Summary
- add Cypress config and a basic end-to-end test
- run Cypress tests from `run_tests.sh` when available
- fetch Cypress in `setup_frontend.sh`
- document how to run UI tests and update contributing guide
- ignore Cypress artefacts
- update sprint docs and backlog for completed sprint
- remove duplicate `dist/` entry from `.gitignore`

## Testing
- `./scripts/run_tests.sh`