### PR TITLE
Verify Cypress installation during frontend setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ npm install -g pnpm@10.5.2
 # Running it offline before the store is populated prints a brief message and
 # skips linting. The script requires `pnpm` to be installed.
 ./scripts/setup_frontend.sh
+# The script also verifies the Cypress binary so UI tests can run offline.
 
 # Install backend dependencies and dev tools (includes `ruff` for linting)
 # Add the `[env]` extra to enable `.env` configuration support

--- a/scripts/setup_frontend.sh
+++ b/scripts/setup_frontend.sh
@@ -6,7 +6,8 @@
 #   @eslint/js, @types/react, @types/react-dom, @vitejs/plugin-react,
 #   eslint, eslint-config-prettier, eslint-plugin-react-hooks,
 #   eslint-plugin-react-refresh, globals, prettier, typescript,
-#   typescript-eslint and vite.
+#   typescript-eslint, vite and cypress. The script also verifies the
+#   Cypress binary so tests run offline once the packages are installed.
 
 # Packages required for offline lints and development
 PKGS=(
@@ -41,6 +42,7 @@ cd "$REPO_ROOT/frontend"
 # fetching them from the registry (requires network) and reinstall
 # from the local store.
 if pnpm install --offline; then
+  pnpm exec cypress verify --quiet >/dev/null 2>&1 || true
   echo "Front-end dependencies installed from offline store."
   exit 0
 fi
@@ -49,6 +51,7 @@ echo "Offline install failed – attempting to fetch packages from registry..."
 if curl -I --max-time 5 https://registry.npmjs.org >/dev/null 2>&1; then
   pnpm fetch --prod=false "${PKGS[@]}"
   pnpm install --offline
+  pnpm exec cypress verify --quiet >/dev/null 2>&1 || true
   echo "Front-end dependencies installed."
   exit 0
 fi


### PR DESCRIPTION
## Summary
- verify the Cypress binary after installing frontend deps
- document the verification step in the quick-start instructions

## Testing
- `./scripts/run_tests.sh` *(fails: Cypress not installed; skipping UI tests)*