### PR TITLE
Remove multi-language support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 
 # Lego GPT ![Coverage](https://codecov.io/gh/JGAVEN/Lego-GPT/branch/main/graph/badge.svg)
 
-Generate buildable **LEGO®** creations directly from your browser.
+Generate buildable **LEGO®** creations directly from your browser. All interface text and prompts are in English only.
 
 ---
 
@@ -41,7 +41,6 @@ real-life building via a built-in Three.js viewer.
 | 🆕 **Offline queue + settings** | Requests made offline are queued and cached results can be cleared in the settings page |
 | 📱 **Install prompt & touch controls** | Add to Home Screen button and smoother mobile controls |
 | 🖼️ **Community example gallery** | Browse shared prompts and load them with one click |
-| 🌐 **Multi-language support** | Switch between English and Spanish in the Settings |
 
 &nbsp;
 
@@ -155,7 +154,6 @@ pnpm --dir frontend run dev    # http://localhost:5173
 # service worker so previously viewed results remain available offline.
 # Requests made while offline are queued and processed once connectivity returns.
 # Browse shared prompts in the Examples page and load them with one click.
-# Use the Settings page to change the interface language.
 # Lint UI code (skips if dependencies are missing)
 pnpm --dir frontend run lint
 # Lint backend code

--- a/docs/PROJECT_BACKLOG.md
+++ b/docs/PROJECT_BACKLOG.md
@@ -60,7 +60,7 @@
 | D-23 | **S**  | Scalability benchmarking                              | **Done** | Benchmark script and tuning docs |
 | F-08 | **C**  | Advanced front-end features                            | **Done** | Offline queue + settings page |
 | F-09 | **C**  | Community example library                             | **Done** | Gallery of prompts and builds |
-| F-10 | **C**  | Multi-language support                                | **Done** | Spanish translations and language switcher |
+| F-10 | **C**  | Multi-language support                                | **Removed** | Interface fixed to English |
 | B-33 | **S**  | Cloud infrastructure templates                       | **Done** | Terraform sample for AWS App Runner |
 | B-34 | **S**  | Automated UI regression tests                        | **Done** | Cypress setup and basic PWA flow test |
 | F-11 | **C**  | Real-time collaboration via WebSocket                | **Done** | `lego-gpt-collab` server |

--- a/docs/SPRINT_PLAN_LATEST.md
+++ b/docs/SPRINT_PLAN_LATEST.md
@@ -24,8 +24,8 @@ This plan outlines the next five logical sprints after completing the advanced f
 ## Sprint 6 – Automated UI regression tests (completed)
 * Added Cypress setup and a basic end-to-end test for the PWA.
 
-## Sprint 7 – Multi-language support (completed)
-* Introduced a language switcher and Spanish translations in the PWA.
+## Sprint 7 – UI text cleanup (completed)
+* Removed the language switcher; the interface is now English only.
 
 ## Sprint 8 – Real-time collaboration (completed)
 * Added a simple WebSocket server and CLI (`lego-gpt-collab`).

--- a/docs/SPRINT_PLAN_NEXT.md
+++ b/docs/SPRINT_PLAN_NEXT.md
@@ -7,6 +7,6 @@ This plan outlines the upcoming sprints after completing the community example l
 ## Sprint 2 – Push notifications
 * Notify users when collaboration partners edit a build.
 
-## Sprint 3 – Additional language support
-* Add French translations to the PWA.
+## Sprint 3 – Interface polish
+* No additional languages are planned; the PWA remains English only.
 

--- a/frontend/src/Settings.tsx
+++ b/frontend/src/Settings.tsx
@@ -8,7 +8,7 @@ import {
 } from "./lib/db";
 
 export default function Settings({ onBack }: { onBack: () => void }) {
-  const { t, lang, setLang } = useI18n();
+  const { t } = useI18n();
   const [cacheCount, setCacheCount] = useState(0);
   const [queueCount, setQueueCount] = useState(0);
 
@@ -24,17 +24,6 @@ export default function Settings({ onBack }: { onBack: () => void }) {
   return (
     <main className="p-6 max-w-xl mx-auto font-sans">
       <h1 className="text-2xl font-bold mb-4">{t("settings")}</h1>
-      <div className="mb-4">
-        <label className="mr-2">{t("language")}</label>
-        <select
-          className="border rounded px-2 py-1"
-          value={lang}
-          onChange={(e) => setLang(e.target.value as typeof lang)}
-        >
-          <option value="en">English</option>
-          <option value="es">Español</option>
-        </select>
-      </div>
       <p>{t("cachedResults")} {cacheCount}</p>
       <p>{t("queuedRequests")} {queueCount}</p>
       <div className="mt-4 space-x-2">

--- a/frontend/src/i18n.tsx
+++ b/frontend/src/i18n.tsx
@@ -1,4 +1,4 @@
-import { createContext, useContext, useState, ReactNode } from "react";
+import { createContext, useContext, ReactNode } from "react";
 
 const en = {
   title: "Lego GPT Demo",
@@ -20,60 +20,23 @@ const en = {
   queuedRequests: "Queued requests:",
   clearCache: "Clear Cache",
   clearQueue: "Clear Queue",
-  language: "Language:",
-};
+}; 
 
-const es: typeof en = {
-  title: "Demostración de Lego GPT",
-  installApp: "Instalar Aplicación",
-  settings: "Configuración",
-  examples: "Ejemplos",
-  prompt: "Solicitud",
-  seedOptional: "Semilla (opcional)",
-  inventoryPhoto: "Foto de Inventario",
-  detecting: "Detectando…",
-  detectedInventory: "Inventario Detectado:",
-  generate: "Generar",
-  generating: "Generando…",
-  viewInAR: "Ver en AR",
-  communityExamples: "Ejemplos de la Comunidad",
-  usePrompt: "Usar Solicitud",
-  back: "Atrás",
-  cachedResults: "Resultados en caché:",
-  queuedRequests: "Solicitudes en cola:",
-  clearCache: "Limpiar Caché",
-  clearQueue: "Vaciar Cola",
-  language: "Idioma:",
-};
-
-const messages = { en, es };
-export type Lang = keyof typeof messages;
+export type Lang = "en";
 export type TransKey = keyof typeof en;
 
 interface I18nContext {
-  lang: Lang;
-  setLang: (l: Lang) => void;
   t: (k: TransKey) => string;
 }
 
 const I18nContext = createContext<I18nContext>({
-  lang: "en",
-  setLang: () => {},
   t: (k: TransKey) => en[k],
 });
 
 export function I18nProvider({ children }: { children: ReactNode }) {
-  const [lang, setLangState] = useState<Lang>(() => {
-    const stored = localStorage.getItem("lang") as Lang | null;
-    return stored ?? "en";
-  });
-  function setLang(l: Lang) {
-    setLangState(l);
-    localStorage.setItem("lang", l);
-  }
-  const t = (k: TransKey) => messages[lang][k] ?? en[k];
+  const t = (k: TransKey) => en[k];
   return (
-    <I18nContext.Provider value={{ lang, setLang, t }}>
+    <I18nContext.Provider value={{ t }}>
       {children}
     </I18nContext.Provider>
   );


### PR DESCRIPTION
## Summary
- drop Spanish language pack and language switcher
- clean up settings page UI
- mark backlog and sprint plans to note English-only UI
- update README to clarify that the program is English only

## Testing
- `python -m unittest discover -v`