### PR TITLE
Implement offline collaboration queue with notifications

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [0.5.42] – 2025-07-15
+### Added
+* Offline collaboration queue with IndexedDB.
+* Push notifications triggered by collaboration events.
+* Demo page showcasing real-time editing.
+
 ## [0.5.41] – 2025-07-02
 ### Added
 * `lego-gpt-collab` WebSocket server for real-time collaboration.

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ real-life building via a built-in Three.js viewer.
 
 &nbsp;
 
-## 2. What’s New (2025-06-13)
+## 2. What’s New (2025-07-01)
 | Change | Impact |
 |--------|--------|
 | 🔄 **Open-source solver** – switched to **OR-Tools 9.10 + HiGHS**. | Runs licence-free everywhere (local dev, CI, containers). |
@@ -39,6 +39,8 @@ real-life building via a built-in Three.js viewer.
 | 🧹 **Cleanup script** (`lego-gpt-cleanup`) | Remove old asset directories (use `--dry-run` to preview) |
 | 🌐 **Collaboration server** (`lego-gpt-collab`) | WebSocket endpoint for real-time shared editing |
 | 🆕 **Offline queue + settings** | Requests made offline are queued and cached results can be cleared in the settings page |
+| 🔔 **Push notifications** | Service worker shows notifications when collaborators edit a build |
+| 📨 **Offline edit queue** | Collaboration messages are stored offline and synced on reconnect |
 | 📱 **Install prompt & touch controls** | Add to Home Screen button and smoother mobile controls |
 | 🖼️ **Community example gallery** | Browse shared prompts and load them with one click |
 
@@ -130,6 +132,9 @@ lego-gpt-server \
 # Start the collaboration server for shared editing
 lego-gpt-collab --host 0.0.0.0 --port 8765
 
+# Access the collaboration demo
+Open the PWA and choose **Collaboration Demo** from the main page to try real-time editing.
+
 # Generate a JWT for requests
 lego-gpt-token --secret mysecret --sub dev > token.txt
 
@@ -207,14 +212,14 @@ Release tags trigger a workflow that builds CPU and GPU images and publishes
 them to GitHub Container Registry.  You can pull the latest versioned images:
 
 ```bash
-docker pull ghcr.io/<owner>/lego-gpt:v0.5.41        # CPU
-docker pull ghcr.io/<owner>/lego-gpt:gpu-v0.5.41    # GPU
+docker pull ghcr.io/<owner>/lego-gpt:v0.5.42        # CPU
+docker pull ghcr.io/<owner>/lego-gpt:gpu-v0.5.42    # GPU
 ```
 
 Run the API server with:
 
 ```bash
-docker run -p 8000:8000 ghcr.io/<owner>/lego-gpt:v0.5.41
+docker run -p 8000:8000 ghcr.io/<owner>/lego-gpt:v0.5.42
 ```
 
 Override the command to start a worker or the detector worker as needed.
@@ -227,7 +232,7 @@ followed by `terraform apply`:
 
 ```bash
 cd infra/aws
-export TF_VAR_api_image=ghcr.io/<owner>/lego-gpt:v0.5.41
+export TF_VAR_api_image=ghcr.io/<owner>/lego-gpt:v0.5.42
 export TF_VAR_redis_url=redis://hostname:6379/0
 export TF_VAR_jwt_secret=$(openssl rand -hex 32)
 terraform init

--- a/backend/__init__.py
+++ b/backend/__init__.py
@@ -22,7 +22,7 @@ except Exception:  # pragma: no cover - ignore if missing
 try:  # pragma: no cover - during editable installs
     __version__ = version("lego-gpt-backend")
 except PackageNotFoundError:  # pragma: no cover - fallback for tests
-    __version__ = "0.5.41"
+    __version__ = "0.5.42"
 
 PACKAGE_DIR = Path(__file__).parent
 _env_static = os.getenv("STATIC_ROOT")

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "lego-gpt-backend"
-version = "0.5.41"
+version = "0.5.42"
 requires-python = ">=3.11"
 dependencies = [
     "redis>=5",

--- a/docs/SPRINT_PLAN_LATEST.md
+++ b/docs/SPRINT_PLAN_LATEST.md
@@ -36,5 +36,14 @@ This plan outlines the next five logical sprints after completing the advanced f
 ## Sprint 10 – Accessibility polish (completed)
 * Added ARIA labels and improved keyboard navigation in the PWA.
 
+## Sprint 11 – Offline mode enhancements (completed)
+* Queued collaboration edits offline and synced them when reconnected.
+
+## Sprint 12 – Push notifications (completed)
+* Service worker displays notifications when collaborators edit a build.
+
+## Sprint 13 – Interface polish (completed)
+* The PWA remains English only and includes a collaboration demo page.
+
 Older sprint plans were combined into `SPRINT_PLAN_ARCHIVE.md` as part of the
 documentation cleanup.

--- a/docs/SPRINT_PLAN_NEXT.md
+++ b/docs/SPRINT_PLAN_NEXT.md
@@ -2,11 +2,11 @@
 
 This plan outlines the upcoming sprints after completing the community example library.
 
-## Sprint 1 – Offline mode enhancements
-* Queue edits offline and sync when reconnected.
-## Sprint 2 – Push notifications
-* Notify users when collaboration partners edit a build.
+## Sprint 1 – Collaborative undo/redo
+* Track edit history and broadcast changes to peers.
+## Sprint 2 – Push subscription management
+* Allow users to enable or disable Web Push notifications.
 
-## Sprint 3 – Interface polish
-* No additional languages are planned; the PWA remains English only.
+## Sprint 3 – Expand example library
+* Accept community submissions and curate featured builds.
 

--- a/frontend/public/sw.js
+++ b/frontend/public/sw.js
@@ -20,3 +20,17 @@ self.addEventListener('fetch', (event) => {
     );
   }
 });
+
+self.addEventListener('push', (event) => {
+  const data = event.data ? event.data.json() : {};
+  const title = data.title || 'Lego GPT';
+  const options = { body: data.body || 'A collaborator edited the build.' };
+  event.waitUntil(self.registration.showNotification(title, options));
+});
+
+self.addEventListener('message', (event) => {
+  if (event.data && event.data.type === 'collab_update') {
+    const body = event.data.body || 'A collaborator edited the build.';
+    self.registration.showNotification('Lego GPT', { body });
+  }
+});

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -11,10 +11,13 @@ import useDetectInventory from "./api/useDetectInventory";
 import LDrawViewer from "./LDrawViewer";
 import Settings from "./Settings";
 import { processPending } from "./lib/offlineQueue";
+import CollabDemo from "./CollabDemo";
 
 export default function App() {
   const { t } = useI18n();
-  const [page, setPage] = useState<"main" | "settings" | "examples">("main");
+  const [page, setPage] = useState<"main" | "settings" | "examples" | "collab">(
+    "main"
+  );
   const [prompt, setPrompt] = useState("");
   const [seed, setSeed] = useState("");
   const [photo, setPhoto] = useState<string | null>(null);
@@ -97,6 +100,10 @@ export default function App() {
     );
   }
 
+  if (page === "collab") {
+    return <CollabDemo onBack={() => setPage("main")} />;
+  }
+
   return (
     <main className="p-6 max-w-xl mx-auto font-sans">
       <h1 className="text-2xl font-bold mb-4">{t("title")}</h1>
@@ -122,6 +129,13 @@ export default function App() {
         aria-label="examples"
       >
         {t("examples")}
+      </button>
+      <button
+        className="text-sm underline mb-4 ml-4"
+        onClick={() => setPage("collab")}
+        aria-label="collaboration demo"
+      >
+        {t("collabDemo")}
       </button>
 
       <form onSubmit={handleSubmit} className="space-y-4">

--- a/frontend/src/CollabDemo.tsx
+++ b/frontend/src/CollabDemo.tsx
@@ -1,0 +1,99 @@
+import { useState, useEffect } from "react";
+import { useI18n } from "./i18n";
+import { queueCollab, processCollabQueue } from "./lib/collabQueue";
+
+interface Props {
+  onBack: () => void;
+}
+
+export default function CollabDemo({ onBack }: Props) {
+  const { t } = useI18n();
+  const [room, setRoom] = useState("");
+  const [message, setMessage] = useState("");
+  const [log, setLog] = useState<string[]>([]);
+  const [ws, setWs] = useState<WebSocket | null>(null);
+
+  useEffect(() => {
+    if (!room) return;
+    const socket = new WebSocket(`ws://${location.host}/ws/${room}`);
+    socket.onopen = () => {
+      processCollabQueue((r, d) => {
+        if (r === room) socket.send(d);
+      });
+    };
+    socket.onmessage = (ev) => {
+      setLog((l) => [...l, ev.data]);
+      if (navigator.serviceWorker.controller) {
+        navigator.serviceWorker.controller.postMessage({
+          type: "collab_update",
+          body: ev.data,
+        });
+      }
+    };
+    setWs(socket);
+    return () => socket.close();
+  }, [room]);
+
+  async function send() {
+    if (!message) return;
+    if (ws && ws.readyState === WebSocket.OPEN) {
+      ws.send(message);
+    } else if (room) {
+      await queueCollab({ room, data: message });
+    }
+    setLog((l) => [...l, `You: ${message}`]);
+    setMessage("");
+  }
+
+  if (!room) {
+    return (
+      <main className="p-6 max-w-xl mx-auto font-sans">
+        <h1 className="text-2xl font-bold mb-4">{t("collabDemo")}</h1>
+        <label className="block mb-2">
+          {t("roomId")}
+          <input
+            className="border rounded w-full px-2 py-1"
+            value={room}
+            onChange={(e) => setRoom(e.target.value)}
+          />
+        </label>
+        <button
+          className="bg-blue-600 text-white px-3 py-1 rounded"
+          onClick={() => setRoom(room.trim())}
+        >
+          {t("send")}
+        </button>
+        <button className="ml-4 underline" onClick={onBack} aria-label="back">
+          {t("back")}
+        </button>
+      </main>
+    );
+  }
+
+  return (
+    <main className="p-6 max-w-xl mx-auto font-sans">
+      <h1 className="text-2xl font-bold mb-4">{t("collabDemo")}</h1>
+      <div className="mb-4">
+        <input
+          className="border rounded w-full px-2 py-1"
+          value={message}
+          onChange={(e) => setMessage(e.target.value)}
+        />
+        <button
+          className="bg-blue-600 text-white px-3 py-1 rounded mt-2"
+          onClick={send}
+        >
+          {t("send")}
+        </button>
+      </div>
+      <ul className="border p-2 h-40 overflow-auto mb-4">
+        {log.map((m, i) => (
+          <li key={i}>{m}</li>
+        ))}
+      </ul>
+      <button className="underline" onClick={onBack} aria-label="back">
+        {t("back")}
+      </button>
+    </main>
+  );
+}

--- a/frontend/src/Settings.tsx
+++ b/frontend/src/Settings.tsx
@@ -5,16 +5,20 @@ import {
   countPendingGenerates,
   clearCachedGenerates,
   clearPendingGenerates,
+  countPendingCollabs,
+  clearPendingCollabs,
 } from "./lib/db";
 
 export default function Settings({ onBack }: { onBack: () => void }) {
   const { t } = useI18n();
   const [cacheCount, setCacheCount] = useState(0);
   const [queueCount, setQueueCount] = useState(0);
+  const [editCount, setEditCount] = useState(0);
 
   async function refresh() {
     setCacheCount(await countCachedGenerates());
     setQueueCount(await countPendingGenerates());
+    setEditCount(await countPendingCollabs());
   }
 
   useEffect(() => {
@@ -26,6 +30,7 @@ export default function Settings({ onBack }: { onBack: () => void }) {
       <h1 className="text-2xl font-bold mb-4">{t("settings")}</h1>
       <p>{t("cachedResults")} {cacheCount}</p>
       <p>{t("queuedRequests")} {queueCount}</p>
+      <p>{t("pendingEdits")} {editCount}</p>
       <div className="mt-4 space-x-2">
         <button
           className="bg-gray-200 px-3 py-1 rounded"
@@ -46,6 +51,16 @@ export default function Settings({ onBack }: { onBack: () => void }) {
           aria-label="clear queue"
         >
           {t("clearQueue")}
+        </button>
+        <button
+          className="bg-gray-200 px-3 py-1 rounded"
+          onClick={async () => {
+            await clearPendingCollabs();
+            refresh();
+          }}
+          aria-label="clear edits"
+        >
+          {t("clearEdits")}
         </button>
       </div>
       <button className="mt-6 text-blue-600 underline" onClick={onBack} aria-label="back">

--- a/frontend/src/i18n.tsx
+++ b/frontend/src/i18n.tsx
@@ -20,7 +20,13 @@ const en = {
   queuedRequests: "Queued requests:",
   clearCache: "Clear Cache",
   clearQueue: "Clear Queue",
-}; 
+  pendingEdits: "Queued edits:",
+  clearEdits: "Clear Edits",
+  collabDemo: "Collaboration Demo",
+  roomId: "Room ID",
+  message: "Message",
+  send: "Send",
+};
 
 export type Lang = "en";
 export type TransKey = keyof typeof en;

--- a/frontend/src/lib/collabQueue.ts
+++ b/frontend/src/lib/collabQueue.ts
@@ -1,0 +1,17 @@
+import { addPendingCollab, getPendingCollabs, deletePendingCollab, PendingCollab } from "./db";
+
+export async function queueCollab(msg: PendingCollab): Promise<void> {
+  await addPendingCollab(msg);
+}
+
+export async function processCollabQueue(send: (room: string, data: string) => Promise<void> | void): Promise<void> {
+  const items = await getPendingCollabs();
+  for (const { id, msg } of items) {
+    try {
+      await send(msg.room, msg.data);
+      await deletePendingCollab(id);
+    } catch {
+      break;
+    }
+  }
+}

--- a/infra/aws/README.md
+++ b/infra/aws/README.md
@@ -10,7 +10,7 @@ It expects a container image published to a registry such as GitHub Container Re
 ## Usage
 1. Export the required variables:
    ```bash
-   export TF_VAR_api_image=ghcr.io/<owner>/lego-gpt:v0.5.41
+   export TF_VAR_api_image=ghcr.io/<owner>/lego-gpt:v0.5.42
    export TF_VAR_redis_url=redis://hostname:6379/0
    export TF_VAR_jwt_secret=$(openssl rand -hex 32)
    # Optional: region, defaults to us-east-1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "lego-gpt"
-version = "0.5.41"
+version = "0.5.42"
 requires-python = ">=3.11"
 
 [build-system]


### PR DESCRIPTION
## Summary
- bump project version to 0.5.42
- add offline collaboration queue and demo page
- integrate push notifications via service worker
- expose queued edit counts in settings
- document new features and update sprint plans

## Testing
- `ruff backend`
- `pytest -q`
