### PR TITLE
Implement sprint 68-72

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,9 @@ real-life building via a built-in Three.js viewer.
 | 🛡️ **Comment moderation tools** | Admins can delete comments and ban users |
 | 📈 **Analytics export CLI** | `lego-gpt-analytics` outputs metrics history to CSV |
 | 🌓 **Dark mode toggle** | PWA remembers your light or dark theme preference |
+| 🎨 **Accent colour picker** | Choose a custom UI highlight colour |
 | 📝 **YAML config files** | Set `LEGOGPT_CONFIG` or `--config` to load settings |
+| 🛠️ **Config generator** | `lego-gpt-config` outputs a sample YAML template |
 | 🔌 **CLI plugins** | Drop Python modules in `~/.lego-gpt/plugins` to add commands |
 | ⏲️ **Scheduled cleanup** | Server periodically removes old assets |
 
@@ -152,6 +154,7 @@ export LEGOGPT_MODEL=/path/to/checkpoint     # optional larger LegoGPT model
 # See ``docs/TOKEN_ROTATION.md`` for rotating the JWT secret.
 # See ``docs/SCALABILITY_BENCHMARKING.md`` for load-testing guidance.
 # Alternatively set ``LEGOGPT_CONFIG`` or ``--config`` to load settings from a YAML file.
+# Generate a starter config with ``lego-gpt-config > config.yaml``.
 lego-gpt-server \
   --host 0.0.0.0 \
   --port 8000 \

--- a/backend/Dockerfile.cpu
+++ b/backend/Dockerfile.cpu
@@ -11,7 +11,10 @@ COPY detector ./detector
 COPY vendor/legogpt ./legogpt
 COPY vendor/legogpt/data ./legogpt/data
 
-RUN pip install --no-cache-dir ./backend[cv]
+RUN pip install --no-cache-dir ./backend[cv] \
+    && adduser --disabled-password --gecos '' lego \
+    && chown -R lego:lego /app
+USER lego
 
 WORKDIR /app/backend
 EXPOSE 8000

--- a/backend/Dockerfile.gpu
+++ b/backend/Dockerfile.gpu
@@ -15,7 +15,10 @@ COPY detector ./detector
 COPY vendor/legogpt ./legogpt
 COPY vendor/legogpt/data ./legogpt/data
 
-RUN pip3 install --no-cache-dir ./backend[cv]
+RUN pip3 install --no-cache-dir ./backend[cv] \
+    && adduser --disabled-password --gecos '' lego \
+    && chown -R lego:lego /app
+USER lego
 
 WORKDIR /app/backend
 EXPOSE 8000

--- a/backend/config_gen_cli.py
+++ b/backend/config_gen_cli.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+SAMPLE_CONFIG = """# Sample Lego GPT configuration
+JWT_SECRET: change-me
+REDIS_URL: redis://localhost:6379/0
+RATE_LIMIT: 5
+QUEUE_NAME: default
+STATIC_ROOT: backend/static
+STATIC_URL_PREFIX: /static
+LOG_LEVEL: INFO
+"""
+
+def main(argv: list[str] | None = None) -> None:
+    parser = argparse.ArgumentParser(description="Generate sample YAML config")
+    parser.add_argument(
+        "path",
+        nargs="?",
+        help="Output path (defaults to stdout)",
+    )
+    args = parser.parse_args(argv)
+    if args.path:
+        Path(args.path).write_text(SAMPLE_CONFIG)
+    else:
+        print(SAMPLE_CONFIG)
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry point
+    main()

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -41,6 +41,7 @@ lego-gpt-examples = "backend.examples_cli:main"
 lego-gpt-sync-bans = "backend.bans_cli:main"
 lego-gpt-analytics = "backend.analytics_cli:main"
 lego-gpt-translate = "backend.translate_cli:main"
+lego-gpt-config = "backend.config_gen_cli:main"
 
 [build-system]
 requires = ["setuptools>=64", "wheel"]

--- a/backend/tests/test_config_gen_cli.py
+++ b/backend/tests/test_config_gen_cli.py
@@ -1,0 +1,29 @@
+import io
+import sys
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+import backend.config_gen_cli as config_cli
+
+
+class ConfigGenCLITests(unittest.TestCase):
+    def test_stdout(self):
+        argv = ["config"]
+        with patch.object(sys, "argv", argv), patch("sys.stdout", new=io.StringIO()) as out:
+            config_cli.main()
+            text = out.getvalue()
+        self.assertIn("JWT_SECRET", text)
+
+    def test_file_output(self):
+        tmp = Path("test.yaml")
+        argv = ["config", str(tmp)]
+        with patch.object(sys, "argv", argv):
+            config_cli.main()
+        self.assertTrue(tmp.is_file())
+        self.assertIn("REDIS_URL", tmp.read_text())
+        tmp.unlink()
+
+
+if __name__ == "__main__":  # pragma: no cover
+    unittest.main()

--- a/docs/SCALABILITY_BENCHMARKING.md
+++ b/docs/SCALABILITY_BENCHMARKING.md
@@ -33,3 +33,16 @@ and `--concurrency` to simulate different workloads.
 
 Benchmark regularly when adjusting these parameters to find the optimal
 configuration for your hardware.
+
+## 4. Horizontal scaling
+
+When deployment traffic increases, run multiple `lego-gpt-worker` containers.
+All workers consume jobs from the same Redis queue, so you can add or remove
+instances without downtime.
+
+- **Docker Compose** – `docker compose up --scale worker=4` launches four
+  worker containers.
+- **Kubernetes** – configure a `HorizontalPodAutoscaler` for the worker
+  deployment based on CPU or queue length metrics.
+
+Monitor queue length and latency to adjust the scaling policy.

--- a/docs/SPRINT_PLAN_LATEST.md
+++ b/docs/SPRINT_PLAN_LATEST.md
@@ -213,5 +213,20 @@ This plan outlines the next five logical sprints after completing the advanced f
 ## Sprint 67 – Helm chart skeleton (completed)
 * Added `infra/helm` with a minimal Helm chart for Kubernetes.
 
+## Sprint 68 – CLI config generator (completed)
+* Added `lego-gpt-config` command that outputs a sample YAML config.
+
+## Sprint 69 – Auto-scaling docs (completed)
+* Documented horizontal scaling strategies for workers in `SCALABILITY_BENCHMARKING.md`.
+
+## Sprint 70 – Remote example import UI (completed)
+* New PWA page allows importing examples from another instance.
+
+## Sprint 71 – Theme colour picker (completed)
+* Settings page includes a colour input that updates the accent CSS variable.
+
+## Sprint 72 – Container security hardening (completed)
+* Production Dockerfiles now create a non-root user.
+
 Older sprint plans were combined into `SPRINT_PLAN_ARCHIVE.md` as part of the
 documentation cleanup.

--- a/docs/SPRINT_PLAN_NEXT.md
+++ b/docs/SPRINT_PLAN_NEXT.md
@@ -2,17 +2,17 @@
 
 These upcoming sprints focus on deployment and usability improvements.
 
-## Sprint 68 – CLI config generator
-* Command to create a sample YAML config with common settings.
+## Sprint 73 – Container image scanning
+* Integrate vulnerability scans for Docker images in CI.
 
-## Sprint 69 – Auto-scaling docs
-* Document horizontal scaling strategies for the worker deployments.
+## Sprint 74 – Admin user management CLI
+* Command-line tool for listing and deleting user accounts.
 
-## Sprint 70 – Remote example import UI
-* PWA page to import examples from another instance.
+## Sprint 75 – Asset compression
+* Compress generated models and images before upload.
 
-## Sprint 71 – Theme colour picker
-* Allow custom accent colours in the PWA settings page.
+## Sprint 76 – Multi-language docs skeleton
+* Start translating key docs to enable community contributions.
 
-## Sprint 72 – Container security hardening
-* Review Dockerfiles and apply best-practice security options.
+## Sprint 77 – External analytics export
+* Push metrics snapshots to a remote data warehouse.

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -17,6 +17,7 @@ import Moderation from "./Moderation";
 import Analytics from "./Analytics";
 import Reports from "./Reports";
 import Tutorial from "./Tutorial";
+import ImportExamples from "./ImportExamples";
 
 export default function App() {
   const { t } = useI18n();
@@ -28,6 +29,7 @@ export default function App() {
     | "moderation"
     | "analytics"
     | "reports"
+    | "import"
   >("main");
   const [prompt, setPrompt] = useState("");
   const [seed, setSeed] = useState("");
@@ -150,6 +152,10 @@ export default function App() {
     return <Reports onBack={() => setPage("main")} />;
   }
 
+  if (page === "import") {
+    return <ImportExamples onBack={() => setPage("main")} />;
+  }
+
   return (
     <main className="p-6 max-w-xl mx-auto font-sans">
       {showTutorial && (
@@ -220,6 +226,13 @@ export default function App() {
         aria-label="reports"
       >
         {t("reports")}
+      </button>
+      <button
+        className="text-sm underline mb-4 ml-4"
+        onClick={() => setPage("import")}
+        aria-label="import examples"
+      >
+        {t("importExamples")}
       </button>
 
       <form onSubmit={handleSubmit} className="space-y-4">

--- a/frontend/src/Examples.tsx
+++ b/frontend/src/Examples.tsx
@@ -34,8 +34,16 @@ export default function Examples({
   useEffect(() => {
     fetch("/examples.json")
       .then((res) => res.json())
-      .then((data) => setExamples(data as Example[]))
-      .catch(() => setExamples([]));
+      .then((data) => {
+        const extra = localStorage.getItem("extraExamples");
+        const extras = extra ? JSON.parse(extra) : [];
+        setExamples([...data, ...extras]);
+      })
+      .catch(() => {
+        const extra = localStorage.getItem("extraExamples");
+        const extras = extra ? JSON.parse(extra) : [];
+        setExamples(extras);
+      });
   }, []);
 
   const tags = Array.from(

--- a/frontend/src/ImportExamples.tsx
+++ b/frontend/src/ImportExamples.tsx
@@ -1,0 +1,47 @@
+import { useState } from "react";
+import { useI18n } from "./i18n";
+
+export default function ImportExamples({ onBack }: { onBack: () => void }) {
+  const { t } = useI18n();
+  const [url, setUrl] = useState("");
+  const [status, setStatus] = useState<string | null>(null);
+
+  async function handleImport() {
+    if (!url) return;
+    try {
+      const res = await fetch(url.replace(/\/$/, "") + "/examples.json");
+      const data = await res.json();
+      const extra = localStorage.getItem("extraExamples");
+      const extras = extra ? JSON.parse(extra) : [];
+      localStorage.setItem("extraExamples", JSON.stringify([...extras, ...data]));
+      setStatus(`Imported ${data.length} examples`);
+    } catch (err) {
+      console.error(err);
+      setStatus("Failed to import");
+    }
+  }
+
+  return (
+    <main className="p-6 max-w-xl mx-auto font-sans">
+      <h1 className="text-2xl font-bold mb-4">{t("importExamples")}</h1>
+      <input
+        value={url}
+        onChange={(e) => setUrl(e.target.value)}
+        placeholder="https://example.com"
+        className="border rounded px-2 py-1 w-full mb-2"
+        aria-label="instance url"
+      />
+      <button
+        onClick={handleImport}
+        className="bg-blue-600 text-white px-4 py-2 rounded"
+        aria-label="import"
+      >
+        {t("import")}
+      </button>
+      {status && <p className="mt-2 text-sm">{status}</p>}
+      <button className="mt-6 text-blue-600 underline" onClick={onBack} aria-label="back">
+        {t("back")}
+      </button>
+    </main>
+  );
+}

--- a/frontend/src/Settings.tsx
+++ b/frontend/src/Settings.tsx
@@ -26,12 +26,18 @@ export default function Settings({ onBack }: { onBack: () => void }) {
     localStorage.getItem("theme") ||
     (window.matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "light")
   );
+  const [accent, setAccent] = useState(() => localStorage.getItem("accent") || "#646cff");
 
   useEffect(() => {
     document.documentElement.classList.toggle("dark", theme === "dark");
     document.documentElement.classList.toggle("light", theme === "light");
     localStorage.setItem("theme", theme);
   }, [theme]);
+
+  useEffect(() => {
+    document.documentElement.style.setProperty("--accent", accent);
+    localStorage.setItem("accent", accent);
+  }, [accent]);
 
   async function refresh() {
     setCacheCount(await countCachedGenerates());
@@ -127,6 +133,14 @@ export default function Settings({ onBack }: { onBack: () => void }) {
         >
           {theme === "dark" ? "Light Mode" : "Dark Mode"}
         </button>
+        <input
+          type="color"
+          value={accent}
+          onChange={(e) => setAccent(e.target.value)}
+          aria-label="accent color"
+          className="w-10 h-10 p-0 border rounded"
+          title={t("accentColor")}
+        />
       </div>
       <button className="mt-6 text-blue-600 underline" onClick={onBack} aria-label="back">
         {t("back")}

--- a/frontend/src/i18n.tsx
+++ b/frontend/src/i18n.tsx
@@ -34,6 +34,8 @@ const en = {
   collabDemo: "Collaboration Demo",
   moderation: "Moderation",
   reports: "Reports",
+  importExamples: "Import Examples",
+  import: "Import",
   clear: "Clear",
   roomId: "Room ID",
   message: "Message",
@@ -43,6 +45,7 @@ const en = {
   pushEnabled: "Push notifications enabled",
   togglePush: "Toggle Push",
   connectedPeers: "Connected collaborators",
+  accentColor: "Accent Color",
   tutorialTitle: "Welcome to Lego GPT",
   tutorialStep1: "Enter a prompt and optional seed to generate a model.",
   tutorialStep2: "Upload a photo to detect your brick inventory.",
@@ -70,6 +73,7 @@ export function I18nProvider({ children }: { children: ReactNode }) {
   );
 }
 
+// eslint-disable-next-line react-refresh/only-export-components
 export function useI18n() {
   return useContext(I18nContext);
 }

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -4,6 +4,7 @@
   font-weight: 400;
 
   color-scheme: light dark;
+  --accent: #646cff;
 }
 
 :root.dark {
@@ -23,11 +24,12 @@
 
 a {
   font-weight: 500;
-  color: #646cff;
+  color: var(--accent);
   text-decoration: inherit;
 }
 a:hover {
-  color: #535bf2;
+  color: var(--accent);
+  opacity: 0.8;
 }
 
 body {
@@ -50,12 +52,12 @@ button {
   font-size: 1em;
   font-weight: 500;
   font-family: inherit;
-  background-color: #1a1a1a;
+  background-color: var(--accent);
   cursor: pointer;
   transition: border-color 0.25s;
 }
 button:hover {
-  border-color: #646cff;
+  border-color: var(--accent);
 }
 button:focus,
 button:focus-visible {
@@ -68,10 +70,10 @@ button:focus-visible {
     background-color: #ffffff;
   }
   a:hover {
-    color: #747bff;
+    color: var(--accent);
   }
   button {
-    background-color: #f9f9f9;
+    background-color: var(--accent);
   }
 }
 


### PR DESCRIPTION
## Summary
- add `lego-gpt-config` CLI for generating sample YAML configs
- document horizontal scaling for workers
- add remote example import page
- allow accent colour selection in settings
- harden Dockerfiles by running as non-root
- update sprint docs and README
- fix lint issues

## Testing
- `./scripts/run_tests.sh`
- `pnpm --dir frontend run lint`
