### PR TITLE
Implement sprint 73-77 features

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,3 +55,20 @@ jobs:
       # 6. (Optional) Build dev Docker image
       # - name: Build Docker image
       #   run: docker build -f Dockerfile.dev -t lego-gpt-dev .
+
+  scan-image:
+    runs-on: ubuntu-latest
+    needs: test
+    steps:
+      - uses: actions/checkout@v4
+      - uses: docker/setup-buildx-action@v3
+      - name: Build Docker image
+        run: docker build -f backend/Dockerfile.cpu -t lego-gpt:test .
+      - name: Scan image with Trivy
+        uses: aquasecurity/trivy-action@v0.19.0
+        with:
+          image-ref: lego-gpt:test
+          format: table
+          exit-code: 1
+          ignore-unfixed: true
+          severity: CRITICAL,HIGH

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+## [0.5.63] – 2025-08-10
+### Added
+- Docker image scanning via Trivy in CI.
+- `lego-gpt-users` CLI lists and deletes user data.
+- Assets uploaded to S3 are gzip-compressed.
+- `lego-gpt-analytics --push-url` sends metrics snapshots remotely.
+- Skeleton folder `docs/i18n/` for translated docs.
+### Changed
+- Backend version bumped to 0.5.63.
+
 ## [0.5.62] – 2025-08-09
 ### Added
 - `lego-gpt-cli completion` outputs shell completion scripts.

--- a/README.md
+++ b/README.md
@@ -189,6 +189,8 @@ lego-gpt-metrics --host 0.0.0.0 --port 8777
 curl -H "Authorization: Bearer $(cat token.txt)" http://localhost:8000/metrics_prom
 # Export metrics history to CSV
 lego-gpt-analytics metrics.csv --token $(cat token.txt)
+# Push metrics to external service
+lego-gpt-analytics - --token $(cat token.txt) --push-url https://example.com/ingest
 
 # Access the collaboration demo
 Open the PWA and choose **Collaboration Demo** from the main page to try real-time editing. A banner shows how many collaborators are connected.
@@ -233,6 +235,8 @@ lego-gpt-cleanup --days 7 --dry-run
 lego-gpt-export model.ldr model.gltf
 # Translate example prompts
 lego-gpt-translate es --url https://api.example.com/translate
+# Manage user data
+lego-gpt-users list
 # Set CLEANUP_DAYS and CLEANUP_DRY_RUN in the environment to persist defaults
 
 # Measure API throughput with 4 concurrent requests

--- a/backend/__init__.py
+++ b/backend/__init__.py
@@ -22,7 +22,7 @@ except Exception:  # pragma: no cover - ignore if missing
 try:  # pragma: no cover - during editable installs
     __version__ = version("lego-gpt-backend")
 except PackageNotFoundError:  # pragma: no cover - fallback for tests
-    __version__ = "0.5.61"
+    __version__ = "0.5.63"
 
 PACKAGE_DIR = Path(__file__).parent
 REDIS_URL = os.getenv("REDIS_URL", "redis://localhost:6379/0")

--- a/backend/analytics_cli.py
+++ b/backend/analytics_cli.py
@@ -26,11 +26,18 @@ def export_csv(data: dict) -> str:
     return "\n".join(lines) + "\n"
 
 
+def _push_csv(url: str, csv_data: str) -> None:
+    req = request.Request(url, data=csv_data.encode(), headers={"Content-Type": "text/csv"})
+    with request.urlopen(req):
+        pass
+
+
 def main(argv: list[str] | None = None) -> None:
     parser = argparse.ArgumentParser(description="Export metrics history to CSV")
     parser.add_argument("file", help="Output CSV file ('-' for stdout)")
     parser.add_argument("--url", default=os.getenv("API_URL", "http://localhost:8000"))
     parser.add_argument("--token", default=os.getenv("JWT"))
+    parser.add_argument("--push-url", help="POST CSV data to this URL")
     args = parser.parse_args(argv)
     if not args.token:
         parser.error("Admin token required")
@@ -43,6 +50,8 @@ def main(argv: list[str] | None = None) -> None:
         print(csv_data, end="")
     else:
         Path(args.file).write_text(csv_data)
+    if args.push_url:
+        _push_csv(args.push_url, csv_data)
 
 
 if __name__ == "__main__":  # pragma: no cover - CLI entry

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "lego-gpt-backend"
-version = "0.5.62"
+version = "0.5.63"
 requires-python = ">=3.11"
 dependencies = [
     "redis>=5",
@@ -42,6 +42,7 @@ lego-gpt-sync-bans = "backend.bans_cli:main"
 lego-gpt-analytics = "backend.analytics_cli:main"
 lego-gpt-translate = "backend.translate_cli:main"
 lego-gpt-config = "backend.config_gen_cli:main"
+lego-gpt-users = "backend.users_cli:main"
 
 [build-system]
 requires = ["setuptools>=64", "wheel"]

--- a/backend/storage.py
+++ b/backend/storage.py
@@ -2,6 +2,9 @@
 from __future__ import annotations
 
 import os
+import mimetypes
+import gzip
+import io
 from pathlib import Path
 from typing import Iterable, Tuple
 
@@ -22,11 +25,20 @@ def _client():
 
 
 def upload(path: Path, key: str) -> str:
-    """Upload a file to S3 and return the public URL."""
+    """Upload a file to S3 and return the public URL with gzip compression."""
     if not S3_BUCKET:
         raise RuntimeError("S3_BUCKET not configured")
     client = _client()
-    client.upload_file(str(path), S3_BUCKET, key)
+    mime, _ = mimetypes.guess_type(str(path))
+    extra: dict[str, str] = {}
+    if mime:
+        extra["ContentType"] = mime
+    extra["ContentEncoding"] = "gzip"
+    with open(path, "rb") as src, io.BytesIO() as buf:
+        with gzip.GzipFile(fileobj=buf, mode="wb") as gz:
+            gz.write(src.read())
+        buf.seek(0)
+        client.upload_fileobj(buf, S3_BUCKET, key, ExtraArgs=extra)
     base = S3_URL_PREFIX.rstrip("/") if S3_URL_PREFIX else f"https://{S3_BUCKET}.s3.amazonaws.com"
     return f"{base}/{key}"
 

--- a/backend/tests/test_analytics_cli.py
+++ b/backend/tests/test_analytics_cli.py
@@ -1,0 +1,30 @@
+import io
+import sys
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+project_root = Path(__file__).resolve().parents[2]
+if str(project_root) not in sys.path:
+    sys.path.insert(0, str(project_root))
+
+import backend.analytics_cli as analytics_cli
+
+
+class AnalyticsCLITests(unittest.TestCase):
+    def test_export_and_push(self):
+        data = {
+            "history": {"req": {"1": 2}}
+        }
+        with patch("backend.analytics_cli._fetch_metrics", return_value=data):
+            with patch("backend.analytics_cli._push_csv") as push_mock:
+                argv = ["analytics", "-", "--token", "t", "--push-url", "http://dst"]
+                with patch.object(sys, "argv", argv), patch("sys.stdout", new=io.StringIO()) as out:
+                    analytics_cli.main()
+                    out_val = out.getvalue().strip()
+                self.assertIn("metric,timestamp,value", out_val)
+                push_mock.assert_called_once()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/backend/tests/test_s3.py
+++ b/backend/tests/test_s3.py
@@ -26,7 +26,7 @@ class S3UploadTests(unittest.TestCase):
             mock_boto.client.return_value = mock_client
             urls, uploaded = storage.maybe_upload_assets([f])
             self.assertTrue(uploaded)
-            mock_client.upload_file.assert_called_once()
+            mock_client.upload_fileobj.assert_called_once()
             self.assertEqual(urls[0], "http://cdn/" + f"{f.parent.name}/{f.name}")
         del os.environ["S3_BUCKET"]
         del os.environ["S3_URL_PREFIX"]

--- a/backend/tests/test_users_cli.py
+++ b/backend/tests/test_users_cli.py
@@ -1,0 +1,36 @@
+import io
+import sys
+import tempfile
+from pathlib import Path
+from unittest.mock import patch
+import unittest
+
+project_root = Path(__file__).resolve().parents[2]
+if str(project_root) not in sys.path:
+    sys.path.insert(0, str(project_root))
+
+import backend.users_cli as users_cli
+
+
+class UsersCLITests(unittest.TestCase):
+    def test_list_and_delete(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            hist = Path(tmpdir) / "history"
+            prefs = Path(tmpdir) / "prefs"
+            hist.mkdir()
+            prefs.mkdir()
+            (hist / "alice.jsonl").write_text("")
+            (prefs / "bob.json").write_text("{}")
+            argv = ["users", "list", "--history-root", str(hist), "--preferences-root", str(prefs)]
+            with patch.object(sys, "argv", argv), patch("sys.stdout", new=io.StringIO()) as out:
+                users_cli.main()
+                result = set(out.getvalue().strip().splitlines())
+            self.assertEqual(result, {"alice", "bob"})
+            argv = ["users", "delete", "alice", "--history-root", str(hist), "--preferences-root", str(prefs)]
+            with patch.object(sys, "argv", argv):
+                users_cli.main()
+            self.assertFalse((hist / "alice.jsonl").exists())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/backend/users_cli.py
+++ b/backend/users_cli.py
@@ -1,0 +1,61 @@
+"""Command-line interface for user management."""
+
+import argparse
+from pathlib import Path
+
+import argparse
+from pathlib import Path
+
+from backend import HISTORY_ROOT, PREFERENCES_ROOT
+
+
+def list_users(history_root: Path, preferences_root: Path) -> list[str]:
+    users = set()
+    if history_root.is_dir():
+        for p in history_root.glob("*.jsonl"):
+            users.add(p.stem)
+    if preferences_root.is_dir():
+        for p in preferences_root.glob("*.json"):
+            users.add(p.stem)
+    return sorted(users)
+
+
+def delete_user(user: str, history_root: Path, preferences_root: Path) -> None:
+    (history_root / f"{user}.jsonl").unlink(missing_ok=True)
+    (preferences_root / f"{user}.json").unlink(missing_ok=True)
+
+
+def main(argv: list[str] | None = None) -> None:
+    parser = argparse.ArgumentParser(description="Manage Lego GPT users")
+    sub = parser.add_subparsers(dest="cmd", required=True)
+
+    ls = sub.add_parser("list", help="List user IDs")
+    ls.add_argument(
+        "--history-root",
+        default=str(HISTORY_ROOT),
+        help="History directory (default: env HISTORY_ROOT)",
+    )
+    ls.add_argument(
+        "--preferences-root",
+        default=str(PREFERENCES_ROOT),
+        help="Preferences directory (default: env PREFERENCES_ROOT)",
+    )
+
+    rm = sub.add_parser("delete", help="Delete user data")
+    rm.add_argument("user", help="User ID to delete")
+    rm.add_argument("--history-root", default=str(HISTORY_ROOT))
+    rm.add_argument("--preferences-root", default=str(PREFERENCES_ROOT))
+
+    args = parser.parse_args(argv)
+    hist = Path(getattr(args, "history_root"))
+    prefs = Path(getattr(args, "preferences_root"))
+
+    if args.cmd == "list":
+        for u in list_users(hist, prefs):
+            print(u)
+    elif args.cmd == "delete":
+        delete_user(args.user, hist, prefs)
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry
+    main()

--- a/docs/PROJECT_BACKLOG.md
+++ b/docs/PROJECT_BACKLOG.md
@@ -92,6 +92,11 @@
 | F-34 | **S**  | Advanced performance budgets                    | **Done** | Lighthouse CI checks accessibility & best practices |
 | F-35 | **S**  | Federated comment moderation                    | **Done** | Sync banned-user lists via new CLI |
 | F-36 | **S**  | Persistent offline queue                       | **Done** | Front-end and CLI store pending requests across sessions |
+| D-24 | **S**  | Container image scanning                       | **Done** | Trivy scan in CI |
+| B-38 | **S**  | Admin user management CLI                      | **Done** | `lego-gpt-users` command |
+| S-16 | **S**  | Asset compression for uploads                  | **Done** | gzip assets before S3 upload |
+| D-25 | **C**  | Multi-language docs skeleton                   | **Done** | `docs/i18n` created |
+| B-39 | **S**  | External analytics export                      | **Done** | CLI `--push-url` option |
 
 
 
@@ -99,4 +104,4 @@
 * **Pri** – MoSCoW priority (**M**ust, **S**hould, **C**ould, **W**on’t-Have-Now).
 * **Status** – Open / WIP / Blocked / Done.
 
-_Last updated 2025-08-07_
+_Last updated 2025-08-10_

--- a/docs/SPRINT_PLAN_LATEST.md
+++ b/docs/SPRINT_PLAN_LATEST.md
@@ -228,5 +228,20 @@ This plan outlines the next five logical sprints after completing the advanced f
 ## Sprint 72 – Container security hardening (completed)
 * Production Dockerfiles now create a non-root user.
 
+## Sprint 73 – Container image scanning (completed)
+* CI job runs Trivy to scan the Docker image.
+
+## Sprint 74 – Admin user management CLI (completed)
+* Added `lego-gpt-users` command for listing and deleting user data.
+
+## Sprint 75 – Asset compression (completed)
+* Assets are gzip-compressed before upload to S3.
+
+## Sprint 76 – Multi-language docs skeleton (completed)
+* New `docs/i18n` directory with initial Spanish stub.
+
+## Sprint 77 – External analytics export (completed)
+* `lego-gpt-analytics` can POST metrics via `--push-url`.
+
 Older sprint plans were combined into `SPRINT_PLAN_ARCHIVE.md` as part of the
 documentation cleanup.

--- a/docs/SPRINT_PLAN_NEXT.md
+++ b/docs/SPRINT_PLAN_NEXT.md
@@ -2,17 +2,17 @@
 
 These upcoming sprints focus on deployment and usability improvements.
 
-## Sprint 73 – Container image scanning
-* Integrate vulnerability scans for Docker images in CI.
+## Sprint 78 – Data warehouse integration docs
+* Document how to connect analytics export to common warehouses.
 
-## Sprint 74 – Admin user management CLI
-* Command-line tool for listing and deleting user accounts.
+## Sprint 79 – CLI plugin examples
+* Provide sample plugins illustrating extension points.
 
-## Sprint 75 – Asset compression
-* Compress generated models and images before upload.
+## Sprint 80 – Staging deployment workflow
+* GitHub Actions workflow for a staging environment.
 
-## Sprint 76 – Multi-language docs skeleton
-* Start translating key docs to enable community contributions.
+## Sprint 81 – User session cleanup
+* Expire old link codes and session tokens automatically.
 
-## Sprint 77 – External analytics export
-* Push metrics snapshots to a remote data warehouse.
+## Sprint 82 – Community translation contributions
+* Guidelines for adding new languages under `docs/i18n`.

--- a/docs/i18n/README.md
+++ b/docs/i18n/README.md
@@ -1,0 +1,4 @@
+# Internationalisation
+
+This folder holds translations of the documentation. Community contributions
+are welcome.

--- a/docs/i18n/es/README.md
+++ b/docs/i18n/es/README.md
@@ -1,0 +1,3 @@
+# Documentación (Español)
+
+La traducción al español está en progreso.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "lego-gpt"
-version = "0.5.61"
+version = "0.5.63"
 requires-python = ">=3.11"
 
 [build-system]


### PR DESCRIPTION
## Summary
- add Trivy container scan in CI
- introduce `lego-gpt-users` CLI
- gzip compress uploaded assets
- allow pushing analytics CSV via `--push-url`
- add multi-language docs skeleton
- document new commands in README and update CHANGELOG
- update sprint plan and backlog
- bump version to 0.5.63

## Testing
- `python -m unittest discover -v`