### PR TITLE
Fix Trivy action version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,7 +65,7 @@ jobs:
       - name: Build Docker image
         run: docker build -f backend/Dockerfile.cpu -t lego-gpt:test .
       - name: Scan image with Trivy
-        uses: aquasecurity/trivy-action@v0.19.0
+        uses: aquasecurity/trivy-action@v0.20.0
         with:
           image-ref: lego-gpt:test
           format: table

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [0.5.65] – 2025-08-12
+### Fixed
+- Updated Trivy GitHub action to `v0.20.0` to resolve missing download error.
+
 ## [0.5.64] – 2025-08-11
 ### Changed
 - Updated build requirements to `setuptools>=78.1.1` to resolve security advisories.

--- a/backend/__init__.py
+++ b/backend/__init__.py
@@ -22,7 +22,7 @@ except Exception:  # pragma: no cover - ignore if missing
 try:  # pragma: no cover - during editable installs
     __version__ = version("lego-gpt-backend")
 except PackageNotFoundError:  # pragma: no cover - fallback for tests
-    __version__ = "0.5.64"
+    __version__ = "0.5.65"
 
 PACKAGE_DIR = Path(__file__).parent
 REDIS_URL = os.getenv("REDIS_URL", "redis://localhost:6379/0")

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "lego-gpt-backend"
-version = "0.5.64"
+version = "0.5.65"
 requires-python = ">=3.11"
 dependencies = [
     "redis>=5",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "lego-gpt"
-version = "0.5.64"
+version = "0.5.65"
 requires-python = ">=3.11"
 
 [build-system]


### PR DESCRIPTION
## Summary
- bump project version to 0.5.65
- update Trivy GitHub Action to v0.20.0
- keep version numbers in backend and pyproject files in sync
- document the change in CHANGELOG

## Testing
- `ruff check backend detector`
- `python -m unittest discover -v`
