### PR TITLE
Implement sprint 73

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [0.5.63] – 2025-08-10
+### Added
+- `lego-gpt-users` CLI lists and deletes user accounts.
+### Changed
+- Backend version bumped to 0.5.63.
+
 ## [0.5.62] – 2025-08-09
 ### Added
 - `lego-gpt-cli completion` outputs shell completion scripts.

--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ real-life building via a built-in Three.js viewer.
 | 🛠️ **Config generator** | `lego-gpt-config` outputs a sample YAML template |
 | 🔌 **CLI plugins** | Drop Python modules in `~/.lego-gpt/plugins` to add commands |
 | ⏲️ **Scheduled cleanup** | Server periodically removes old assets |
+| 🧑‍💻 **User management CLI** | `lego-gpt-users` lists and deletes accounts |
 
 &nbsp;
 

--- a/backend/__init__.py
+++ b/backend/__init__.py
@@ -22,7 +22,7 @@ except Exception:  # pragma: no cover - ignore if missing
 try:  # pragma: no cover - during editable installs
     __version__ = version("lego-gpt-backend")
 except PackageNotFoundError:  # pragma: no cover - fallback for tests
-    __version__ = "0.5.61"
+    __version__ = "0.5.63"
 
 PACKAGE_DIR = Path(__file__).parent
 REDIS_URL = os.getenv("REDIS_URL", "redis://localhost:6379/0")

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "lego-gpt-backend"
-version = "0.5.62"
+version = "0.5.63"
 requires-python = ">=3.11"
 dependencies = [
     "redis>=5",
@@ -44,6 +44,7 @@ lego-gpt-sync-bans = "backend.bans_cli:main"
 lego-gpt-analytics = "backend.analytics_cli:main"
 lego-gpt-translate = "backend.translate_cli:main"
 lego-gpt-config = "backend.config_gen_cli:main"
+lego-gpt-users = "backend.user_cli:main"
 
 [build-system]
 requires = ["setuptools>=64", "wheel"]

--- a/backend/tests/test_user_cli.py
+++ b/backend/tests/test_user_cli.py
@@ -1,0 +1,56 @@
+import io
+import sys
+import tempfile
+import unittest
+from unittest import mock
+from pathlib import Path
+
+project_root = Path(__file__).resolve().parents[2]
+if str(project_root) not in sys.path:
+    sys.path.insert(0, str(project_root))
+
+import backend.user_cli as user_cli
+
+
+class UserCLITests(unittest.TestCase):
+    def test_list_and_delete(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            hist = Path(tmpdir) / "history"
+            prefs = Path(tmpdir) / "prefs"
+            hist.mkdir()
+            prefs.mkdir()
+            (hist / "alice.jsonl").write_text("log")
+            (prefs / "bob.json").write_text("{}")
+
+            argv = [
+                "users",
+                "--history",
+                str(hist),
+                "--prefs",
+                str(prefs),
+                "list",
+            ]
+            with mock.patch.object(sys, "argv", argv), io.StringIO() as buf, mock.patch(
+                "sys.stdout", buf
+            ):
+                user_cli.main()
+                out = buf.getvalue().splitlines()
+            self.assertIn("alice", out)
+            self.assertIn("bob", out)
+
+            argv = [
+                "users",
+                "--history",
+                str(hist),
+                "--prefs",
+                str(prefs),
+                "delete",
+                "alice",
+            ]
+            with mock.patch.object(sys, "argv", argv):
+                user_cli.main()
+            self.assertFalse((hist / "alice.jsonl").exists())
+
+
+if __name__ == "__main__":  # pragma: no cover
+    unittest.main()

--- a/backend/user_cli.py
+++ b/backend/user_cli.py
@@ -1,0 +1,63 @@
+"""CLI to manage user accounts."""
+from __future__ import annotations
+
+import argparse
+import os
+from pathlib import Path
+
+from backend import HISTORY_ROOT, PREFERENCES_ROOT
+
+
+def list_users(history: Path, prefs: Path) -> list[str]:
+    """Return sorted list of known user IDs."""
+    users: set[str] = set()
+    if history.is_dir():
+        for p in history.glob("*.jsonl"):
+            users.add(p.stem)
+    if prefs.is_dir():
+        for p in prefs.glob("*.json"):
+            users.add(p.stem)
+    return sorted(users)
+
+
+def delete_user(user: str, history: Path, prefs: Path) -> None:
+    """Remove all data for ``user``."""
+    hist_file = history / f"{user}.jsonl"
+    pref_file = prefs / f"{user}.json"
+    if hist_file.is_file():
+        hist_file.unlink()
+    if pref_file.is_file():
+        pref_file.unlink()
+
+
+def main(argv: list[str] | None = None) -> None:
+    parser = argparse.ArgumentParser(description="Manage user accounts")
+    parser.add_argument(
+        "--history",
+        default=os.getenv("HISTORY_ROOT", str(HISTORY_ROOT)),
+        help="Directory with build history files",
+    )
+    parser.add_argument(
+        "--prefs",
+        default=os.getenv("PREFERENCES_ROOT", str(PREFERENCES_ROOT)),
+        help="Directory with preference files",
+    )
+    sub = parser.add_subparsers(dest="cmd")
+    sub.add_parser("list", help="List known users")
+    del_p = sub.add_parser("delete", help="Delete a user")
+    del_p.add_argument("user", help="User ID")
+    args = parser.parse_args(argv)
+
+    history = Path(args.history)
+    prefs = Path(args.prefs)
+    if args.cmd == "list":
+        for u in list_users(history, prefs):
+            print(u)
+    elif args.cmd == "delete":
+        delete_user(args.user, history, prefs)
+    else:
+        parser.print_help()
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main()

--- a/docs/SPRINT_PLAN_LATEST.md
+++ b/docs/SPRINT_PLAN_LATEST.md
@@ -228,5 +228,8 @@ This plan outlines the next five logical sprints after completing the advanced f
 ## Sprint 72 – Container security hardening (completed)
 * Production Dockerfiles now create a non-root user.
 
+## Sprint 73 – Admin user management CLI (completed)
+* Added `lego-gpt-users` tool for listing and deleting accounts.
+
 Older sprint plans were combined into `SPRINT_PLAN_ARCHIVE.md` as part of the
 documentation cleanup.

--- a/docs/SPRINT_PLAN_NEXT.md
+++ b/docs/SPRINT_PLAN_NEXT.md
@@ -2,9 +2,6 @@
 
 These upcoming sprints focus on deployment and usability improvements.
 
-## Sprint 73 – Admin user management CLI
-* Command-line tool for listing and deleting user accounts.
-
 ## Sprint 74 – Asset compression
 * Compress generated models and images before upload.
 
@@ -16,3 +13,6 @@ These upcoming sprints focus on deployment and usability improvements.
 
 ## Sprint 77 – Project wrap-up
 * Finalise documentation and prepare the repository for archival.
+
+## Sprint 78 – Post-launch maintenance
+* Address bug reports and triage community PRs.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "lego-gpt"
-version = "0.5.61"
+version = "0.5.63"
 requires-python = ">=3.11"
 
 [build-system]


### PR DESCRIPTION
## Notes
- Added `lego-gpt-users` CLI for admins to list and delete user accounts
- Bumped version to 0.5.63 and documented the new CLI
- Updated sprint plans and next tasks
- Included unit tests for the new command

## Testing
- `ruff check .`
- `pytest -q`