### PR TITLE
Clarify lack of multilingual support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 
 # Lego GPT ![Coverage](https://codecov.io/gh/JGAVEN/Lego-GPT/branch/main/graph/badge.svg)
 
-Generate buildable **LEGO®** creations directly from your browser. All interface text and prompts are in English only.
+Generate buildable **LEGO®** creations directly from your browser. All interface text and prompts are in English only. The application does not include multilingual support and expects English input throughout.
 
 ---
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,6 +1,8 @@
 
 # Architecture
 
+All components assume English input and output. The system does not provide multilingual support.
+
 ```
 ┌──────────────┐   HTTPS POST /generate   ┌────────────────────────────────────────┐
 │  PWA Client  │◄────────────────────────►│   HTTP Gateway (API)                │

--- a/docs/PROJECT_BACKLOG.md
+++ b/docs/PROJECT_BACKLOG.md
@@ -1,6 +1,8 @@
 
 # Project Backlog (MoSCoW)
 
+The application is English-only. Multi-language user interfaces are out of scope.
+
 | ID   | Pri | Title                               | Status | Notes |
 |------|-----|-------------------------------------|--------|-------|
 | B‑1 | **v0.5** Inventory Detection | Fine‑tune YOLOv8 on 3 k brick images | CV lead | **Done**: training Dockerfile and docs |
@@ -60,7 +62,7 @@
 | D-23 | **S**  | Scalability benchmarking                              | **Done** | Benchmark script and tuning docs |
 | F-08 | **C**  | Advanced front-end features                            | **Done** | Offline queue + settings page |
 | F-09 | **C**  | Community example library                             | **Done** | Gallery of prompts and builds |
-| F-10 | **C**  | Multi-language support                                | **Removed** | Interface fixed to English |
+| F-10 | **C**  | Multi-language support                                | **Removed** | Interface fixed to English; no further translation work planned |
 | B-33 | **S**  | Cloud infrastructure templates                       | **Done** | Terraform sample for AWS App Runner |
 | B-34 | **S**  | Automated UI regression tests                        | **Done** | Cypress setup and basic PWA flow test |
 | F-11 | **C**  | Real-time collaboration via WebSocket                | **Done** | `lego-gpt-collab` server |

--- a/docs/SPRINT_PLAN_LATEST.md
+++ b/docs/SPRINT_PLAN_LATEST.md
@@ -1,6 +1,6 @@
 # Latest Sprint Plan
 
-This plan outlines the next five logical sprints after completing the advanced front-end features.
+This plan outlines the next five logical sprints after completing the advanced front-end features. The application UI is English only and no multilingual support is planned.
 
 ## Sprint 1 – Cloud infrastructure templates (completed)
 * Added `infra/aws` sample using Terraform and App Runner.
@@ -233,3 +233,4 @@ This plan outlines the next five logical sprints after completing the advanced f
 
 Older sprint plans were combined into `SPRINT_PLAN_ARCHIVE.md` as part of the
 documentation cleanup.
+The feature set is now stable with an English-only interface and no plans for multi-language support.

--- a/docs/SPRINT_PLAN_NEXT.md
+++ b/docs/SPRINT_PLAN_NEXT.md
@@ -6,7 +6,7 @@ These upcoming sprints focus on deployment and usability improvements.
 * Compress generated models and images before upload.
 
 ## Sprint 75 – Multi-language docs skeleton
-* Start translating key docs to enable community contributions.
+* Translate key documentation files for community contributors. The program itself remains English only.
 
 ## Sprint 76 – External analytics export
 * Push metrics snapshots to a remote data warehouse.


### PR DESCRIPTION
## Summary
- state clearly in README that the app does not support multiple languages
- note English-only UI in Architecture doc
- emphasise English-only focus in backlog
- mark sprint plan sections to clarify docs translation only
- update latest sprint plan with final English-only note

## Testing
- `python -m unittest discover -v`