### PR TITLE
Implement sprint 74 asset compression

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [0.5.64] – 2025-08-11
+### Added
+- Assets are gzipped before S3 upload for smaller transfers.
+### Changed
+- Backend version bumped to 0.5.64.
+
 ## [0.5.63] – 2025-08-10
 ### Added
 - `lego-gpt-users` CLI lists and deletes user accounts.

--- a/README.md
+++ b/README.md
@@ -178,6 +178,7 @@ lego-gpt-server \
 # Set ``CORS_ORIGINS`` or pass ``--cors-origins <origins>`` to control the
 # ``Access-Control-Allow-Origin`` header.
 # Set ``S3_BUCKET`` and optional ``S3_URL_PREFIX`` to upload assets to S3/R2.
+# Generated files are gzipped before upload when this is enabled.
 # Set ``SMTP_HOST`` and ``COMMENT_NOTIFY_EMAIL`` to enable comment notifications.
 # Optionally configure ``SMTP_USER``, ``SMTP_PASSWORD`` and ``SMTP_FROM``.
 

--- a/backend/__init__.py
+++ b/backend/__init__.py
@@ -22,7 +22,7 @@ except Exception:  # pragma: no cover - ignore if missing
 try:  # pragma: no cover - during editable installs
     __version__ = version("lego-gpt-backend")
 except PackageNotFoundError:  # pragma: no cover - fallback for tests
-    __version__ = "0.5.63"
+    __version__ = "0.5.64"
 
 PACKAGE_DIR = Path(__file__).parent
 REDIS_URL = os.getenv("REDIS_URL", "redis://localhost:6379/0")

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "lego-gpt-backend"
-version = "0.5.63"
+version = "0.5.64"
 requires-python = ">=3.11"
 dependencies = [
     "redis>=5",

--- a/backend/storage.py
+++ b/backend/storage.py
@@ -2,6 +2,10 @@
 from __future__ import annotations
 
 import os
+import gzip
+import mimetypes
+import shutil
+import tempfile
 from pathlib import Path
 from typing import Iterable, Tuple
 
@@ -26,7 +30,23 @@ def upload(path: Path, key: str) -> str:
     if not S3_BUCKET:
         raise RuntimeError("S3_BUCKET not configured")
     client = _client()
-    client.upload_file(str(path), S3_BUCKET, key)
+    extra = {}
+    tmp_name = None
+    try:
+        if os.getenv("COMPRESS_UPLOADS", "1") == "1":
+            with tempfile.NamedTemporaryFile(delete=False, suffix=".gz") as tmp:
+                with open(path, "rb") as src, gzip.GzipFile(fileobj=tmp, mode="wb") as gz:
+                    shutil.copyfileobj(src, gz)
+                tmp_name = tmp.name
+            ctype = mimetypes.guess_type(path.name)[0] or "application/octet-stream"
+            extra = {"ContentType": ctype, "ContentEncoding": "gzip"}
+            upload_path = tmp_name
+        else:
+            upload_path = str(path)
+        client.upload_file(upload_path, S3_BUCKET, key, ExtraArgs=extra)  # type: ignore[arg-type]
+    finally:
+        if tmp_name:
+            os.unlink(tmp_name)
     base = S3_URL_PREFIX.rstrip("/") if S3_URL_PREFIX else f"https://{S3_BUCKET}.s3.amazonaws.com"
     return f"{base}/{key}"
 

--- a/backend/tests/test_s3.py
+++ b/backend/tests/test_s3.py
@@ -27,6 +27,9 @@ class S3UploadTests(unittest.TestCase):
             urls, uploaded = storage.maybe_upload_assets([f])
             self.assertTrue(uploaded)
             mock_client.upload_file.assert_called_once()
+            args, kwargs = mock_client.upload_file.call_args
+            self.assertIn("ExtraArgs", kwargs)
+            self.assertEqual(kwargs["ExtraArgs"].get("ContentEncoding"), "gzip")
             self.assertEqual(urls[0], "http://cdn/" + f"{f.parent.name}/{f.name}")
         del os.environ["S3_BUCKET"]
         del os.environ["S3_URL_PREFIX"]

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -61,15 +61,17 @@ clusters not connected to the ground.
    (or set ``STATIC_ROOT``) to override the directory. Use
    ``STATIC_URL_PREFIX`` to customise the URL prefix returned to the
    client (defaults to ``/static``).
-6. When finished, a GET on `/generate/{job_id}` returns `{png_url, ldr_url, gltf_url, instructions_url, brick_counts}`. Each completed build is logged under ``HISTORY_ROOT`` and can be retrieved via ``/history``.
-7. Clients may subscribe to `/progress/{job_id}` for Server-Sent Events with
+6. If ``S3_BUCKET`` is configured, each file is gzipped and uploaded with
+   ``Content-Encoding: gzip`` for efficient storage.
+7. When finished, a GET on `/generate/{job_id}` returns `{png_url, ldr_url, gltf_url, instructions_url, brick_counts}`. Each completed build is logged under ``HISTORY_ROOT`` and can be retrieved via ``/history``.
+8. Clients may subscribe to `/progress/{job_id}` for Server-Sent Events with
    `{"progress": 0..100}` updates.
-8. Client shows PNG immediately; Three.js lazily loads LDR → interactive viewer.
+9. Client shows PNG immediately; Three.js lazily loads LDR → interactive viewer.
    The `LDrawLoader` module is fetched from a CDN at runtime.
-9. Set ``LOG_LEVEL`` or pass ``--log-level`` to server/workers to control logging verbosity.
-10. Environment variables can be placed in a ``.env`` file. If
+10. Set ``LOG_LEVEL`` or pass ``--log-level`` to server/workers to control logging verbosity.
+11. Environment variables can be placed in a ``.env`` file. If
    ``python-dotenv`` is installed, the backend loads it automatically on startup.
-11. Set ``ORTOOLS_ENGINE`` or pass ``--solver-engine`` to the worker to pick a
+12. Set ``ORTOOLS_ENGINE`` or pass ``--solver-engine`` to the worker to pick a
     specific OR-Tools backend (``HIGHs`` or ``CBC``).
 
 Community members can post new prompt ideas via ``POST /submit_example``. Each

--- a/docs/SPRINT_PLAN_LATEST.md
+++ b/docs/SPRINT_PLAN_LATEST.md
@@ -231,6 +231,9 @@ This plan outlines the next five logical sprints after completing the advanced f
 ## Sprint 73 – Admin user management CLI (completed)
 * Added `lego-gpt-users` tool for listing and deleting accounts.
 
+## Sprint 74 – Asset compression (completed)
+* Generated images and models are gzipped before uploading to S3.
+
 Older sprint plans were combined into `SPRINT_PLAN_ARCHIVE.md` as part of the
 documentation cleanup.
 The feature set is now stable with an English-only interface and no plans for multi-language support.

--- a/docs/SPRINT_PLAN_NEXT.md
+++ b/docs/SPRINT_PLAN_NEXT.md
@@ -2,9 +2,6 @@
 
 These upcoming sprints focus on deployment and usability improvements.
 
-## Sprint 74 – Asset compression
-* Compress generated models and images before upload.
-
 ## Sprint 75 – Multi-language docs skeleton
 * Translate key documentation files for community contributors. The program itself remains English only.
 
@@ -16,3 +13,6 @@ These upcoming sprints focus on deployment and usability improvements.
 
 ## Sprint 78 – Post-launch maintenance
 * Address bug reports and triage community PRs.
+
+## Sprint 79 – Final archive
+* Tag the final release and archive the repository.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "lego-gpt"
-version = "0.5.63"
+version = "0.5.64"
 requires-python = ">=3.11"
 
 [build-system]


### PR DESCRIPTION
## Summary
- gzip generated assets before uploading to S3
- document new compression step in architecture docs
- record sprint 74 completion
- bump backend version to 0.5.64 and update changelog
- update README env var docs
- expand S3 tests for Content-Encoding
- plan future sprints 75–79

## Testing
- `scripts/run_tests.sh`
- `pytest -q`
