### PR TITLE
Document English-only launch

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,3 +1,5 @@
+<!-- Lego GPT launches in English only with no multilingual support. -->
+
 ## Title
 
 <!-- Concise summary of the issue -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,3 +1,5 @@
+<!-- Lego GPT is English only; do not add multilingual features yet. -->
+
 ## Description
 
 <!-- Describe what this PR does and why it matters -->

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+> **Note**: The application launches with an English-only interface and has no multilingual support.
 ## [0.5.64] – 2025-08-11
 ### Added
 - Assets are gzipped before S3 upload for smaller transfers.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,8 @@
 # Contributing & AI‑Agent Workflow
 
 This project is developed by a **human owner (Jeff) plus ChatGPT‑4o “dev agents”.**
+> **Note**: The application launches with an English-only interface and does not support multiple languages.
+
 
 ## Ground rules for *all* dev agents
 

--- a/README.md
+++ b/README.md
@@ -235,6 +235,7 @@ lego-gpt-cleanup --days 7 --dry-run
 lego-gpt-export model.ldr model.gltf
 # Translate example prompts
 lego-gpt-translate es --url https://api.example.com/translate
+# This command translates example prompts only; the app itself is English-only.
 # Set CLEANUP_DAYS and CLEANUP_DRY_RUN in the environment to persist defaults
 
 # Measure API throughput with 4 concurrent requests

--- a/docs/DETECTOR_DATASET.md
+++ b/docs/DETECTOR_DATASET.md
@@ -1,5 +1,7 @@
 # Brick Detector Dataset Format
 
+> **Note**: The project launches with an English-only interface and does not support additional languages.
+
 This document describes the expected layout for training the YOLOv8 brick detector with the `lego-detect-train` command.
 
 The dataset should follow the standard [Ultralytics](https://docs.ultralytics.com/datasets/detect/) directory structure:

--- a/docs/EXAMPLES.md
+++ b/docs/EXAMPLES.md
@@ -1,5 +1,7 @@
 # Community Examples
 
+> **Note**: Lego GPT is English-only at launch. Example prompts should also be provided in English.
+
 The front-end loads sample prompts from `frontend/public/examples.json`. Each entry has an `id`, `title`, `prompt`, `image` URL and a list of keyword `tags`. Contributions are welcome. To add a new example:
 
 1. Add an object to `examples.json` with a unique `id`.

--- a/docs/SCALABILITY_BENCHMARKING.md
+++ b/docs/SCALABILITY_BENCHMARKING.md
@@ -1,5 +1,7 @@
 # Scalability Benchmarking
 
+> **Note**: The application launches with an English-only interface and does not support additional languages.
+
 This guide explains how to measure API throughput and tune your deployment.
 
 ## 1. Prerequisites

--- a/docs/SPRINT_PLAN_ARCHIVE.md
+++ b/docs/SPRINT_PLAN_ARCHIVE.md
@@ -1,5 +1,7 @@
 # Sprint Plan Archive
 
+> **Note**: Lego GPT ships with an English-only interface and does not support multiple languages.
+
 This document consolidates the historical sprint plans for Lego GPT. All completed plans are summarised here for reference.
 
 ## Initial Roadmap

--- a/docs/SPRINT_PLAN_NEXT.md
+++ b/docs/SPRINT_PLAN_NEXT.md
@@ -1,5 +1,7 @@
 # Next Sprint Plan
 
+> **Note**: The software launches in English only; multilingual support is not included.
+
 These upcoming sprints focus on deployment and usability improvements.
 
 ## Sprint 75 – Multi-language docs skeleton

--- a/docs/TOKEN_ROTATION.md
+++ b/docs/TOKEN_ROTATION.md
@@ -1,5 +1,7 @@
 # JWT Token Rotation
 
+> **Note**: The application is English-only at launch with no multilingual support.
+
 To rotate authentication tokens:
 
 1. **Generate a new secret**

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1,5 +1,7 @@
 # React + TypeScript + Vite
 
+> **Note**: The application launches with an English-only interface; no translations are provided.
+
 This template provides a minimal setup to get React working in Vite with HMR and some ESLint rules.
 
 Currently, two official plugins are available:

--- a/infra/README.md
+++ b/infra/README.md
@@ -1,5 +1,7 @@
 # Infrastructure Samples
 
+> **Note**: The software ships with an English-only interface. The infrastructure samples do not include localisation support.
+
 Sample configurations for deploying Lego GPT to cloud providers.
 
 - `aws/` – deploys the API using AWS App Runner.

--- a/infra/aws/README.md
+++ b/infra/aws/README.md
@@ -1,5 +1,7 @@
 # AWS Terraform Sample
 
+> **Note**: Lego GPT runs in English only. The Terraform sample does not configure translations.
+
 This folder contains a minimal Terraform configuration for deploying the Lego GPT API to [AWS App Runner](https://aws.amazon.com/apprunner/).
 It expects a container image published to a registry such as GitHub Container Registry or Amazon ECR Public.
 

--- a/infra/helm/README.md
+++ b/infra/helm/README.md
@@ -1,5 +1,7 @@
 # Lego GPT Helm Chart
 
+> **Note**: The Helm chart assumes the application is English-only; no localisation is provided.
+
 This chart provides a simple way to deploy Lego GPT on Kubernetes using Helm.
 It mirrors the manifests in `../k8s` but exposes a few configurable values.
 

--- a/infra/k8s/README.md
+++ b/infra/k8s/README.md
@@ -1,5 +1,7 @@
 # Kubernetes Sample
 
+> **Note**: The provided Kubernetes manifests assume the application is English-only.
+
 This folder provides a minimal set of manifests for running Lego GPT on Kubernetes. The manifests assume a container image is already available in a registry and that all services can share a Redis instance within the cluster.
 
 ## Usage


### PR DESCRIPTION
## Summary
- note English-only status across docs
- clarify that lego-gpt-translate doesn't imply multilingual support

## Testing
- `./scripts/run_tests.sh` *(fails: missing network packages)*