### PR TITLE
Remove multilingual sprint items

### DIFF
--- a/docs/SPRINT_PLAN_LATEST.md
+++ b/docs/SPRINT_PLAN_LATEST.md
@@ -207,31 +207,28 @@ This plan outlines the next five logical sprints after completing the advanced f
 ## Sprint 65 – Prometheus metrics exporter (completed)
 * `/metrics_prom` returns counters in Prometheus format.
 
-## Sprint 66 – Example translation workflow (completed)
-* `lego-gpt-translate` CLI translates example prompts via an external API.
-
-## Sprint 67 – Helm chart skeleton (completed)
+## Sprint 66 – Helm chart skeleton (completed)
 * Added `infra/helm` with a minimal Helm chart for Kubernetes.
 
-## Sprint 68 – CLI config generator (completed)
+## Sprint 67 – CLI config generator (completed)
 * Added `lego-gpt-config` command that outputs a sample YAML config.
 
-## Sprint 69 – Auto-scaling docs (completed)
+## Sprint 68 – Auto-scaling docs (completed)
 * Documented horizontal scaling strategies for workers in `SCALABILITY_BENCHMARKING.md`.
 
-## Sprint 70 – Remote example import UI (completed)
+## Sprint 69 – Remote example import UI (completed)
 * New PWA page allows importing examples from another instance.
 
-## Sprint 71 – Theme colour picker (completed)
+## Sprint 70 – Theme colour picker (completed)
 * Settings page includes a colour input that updates the accent CSS variable.
 
-## Sprint 72 – Container security hardening (completed)
+## Sprint 71 – Container security hardening (completed)
 * Production Dockerfiles now create a non-root user.
 
-## Sprint 73 – Admin user management CLI (completed)
+## Sprint 72 – Admin user management CLI (completed)
 * Added `lego-gpt-users` tool for listing and deleting accounts.
 
-## Sprint 74 – Asset compression (completed)
+## Sprint 73 – Asset compression (completed)
 * Generated images and models are gzipped before uploading to S3.
 
 Older sprint plans were combined into `SPRINT_PLAN_ARCHIVE.md` as part of the

--- a/docs/SPRINT_PLAN_NEXT.md
+++ b/docs/SPRINT_PLAN_NEXT.md
@@ -4,17 +4,14 @@
 
 These upcoming sprints focus on deployment and usability improvements.
 
-## Sprint 75 – Multi-language docs skeleton
-* Translate key documentation files for community contributors. The program itself remains English only.
-
-## Sprint 76 – External analytics export
+## Sprint 75 – External analytics export
 * Push metrics snapshots to a remote data warehouse.
 
-## Sprint 77 – Project wrap-up
+## Sprint 76 – Project wrap-up
 * Finalise documentation and prepare the repository for archival.
 
-## Sprint 78 – Post-launch maintenance
+## Sprint 77 – Post-launch maintenance
 * Address bug reports and triage community PRs.
 
-## Sprint 79 – Final archive
+## Sprint 78 – Final archive
 * Tag the final release and archive the repository.


### PR DESCRIPTION
## Summary
- remove multi-language documentation sprint from next plan
- remove example translation sprint from latest plan
- renumber subsequent sprints

## Testing
- `./scripts/run_tests.sh`