### PR TITLE
Add maintenance docs and container scan

### DIFF
--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -1,0 +1,22 @@
+name: Container Scan
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+  schedule:
+    - cron: '0 3 * * 0'
+
+jobs:
+  scan:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Run Trivy filesystem scan
+        uses: aquasecurity/trivy-action@v0.19.0
+        with:
+          scan-type: fs
+          scan-ref: .
+          ignore-unfixed: true
+          severity: CRITICAL,HIGH
+          exit-code: 1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [0.5.68] – 2025-05-27
+### Changed
+* Backend package version bumped to 0.5.68.
+### Added
+* Issue triage guidelines and long-term support policy docs.
+* Trivy workflow for container vulnerability scanning.
+
 ## [0.5.67] – 2025-05-27
 ### Changed
 * Backend package version bumped to 0.5.67.

--- a/README.md
+++ b/README.md
@@ -472,5 +472,8 @@ fork the project and submit security patches. A static
 announcement is available at `frontend/public/sunset.html`.
 Pinned package versions are listed in
 [docs/DEPENDENCY_VERSIONS.md](docs/DEPENDENCY_VERSIONS.md).
+See [docs/LTS_POLICY.md](docs/LTS_POLICY.md) for the long-term support window.
+Issue triage steps are documented in
+[docs/ISSUE_TRIAGE_GUIDE.md](docs/ISSUE_TRIAGE_GUIDE.md).
 
 For creating a new release, follow the steps in [docs/RELEASE_PROCESS.md](docs/RELEASE_PROCESS.md). Documentation is mirrored as a static site (see [docs/ARCHIVE_SITE.md](docs/ARCHIVE_SITE.md)).

--- a/backend/__init__.py
+++ b/backend/__init__.py
@@ -22,7 +22,7 @@ except Exception:  # pragma: no cover - ignore if missing
 try:  # pragma: no cover - during editable installs
     __version__ = version("lego-gpt-backend")
 except PackageNotFoundError:  # pragma: no cover - fallback for tests
-    __version__ = "0.5.67"
+    __version__ = "0.5.68"
 
 PACKAGE_DIR = Path(__file__).parent
 REDIS_URL = os.getenv("REDIS_URL", "redis://localhost:6379/0")

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "lego-gpt-backend"
-version = "0.5.67"
+version = "0.5.68"
 requires-python = ">=3.11"
 dependencies = [
     "redis==5.0.0",

--- a/docs/COMMUNITY_MAINTENANCE.md
+++ b/docs/COMMUNITY_MAINTENANCE.md
@@ -1,6 +1,7 @@
 # Community Maintenance Guide
 
 This project is now community‑maintained. The codebase remains English‑only and receives security fixes only.
+See [LTS_POLICY.md](LTS_POLICY.md) for details on the support timeline.
 
 ## Forking
 1. Use the GitHub **Fork** button to create your own copy.

--- a/docs/ISSUE_TRIAGE_GUIDE.md
+++ b/docs/ISSUE_TRIAGE_GUIDE.md
@@ -1,0 +1,23 @@
+# Issue Triage Guidelines
+
+> **Note**: The software and documentation are provided in English only.
+
+This guide explains how maintainers should handle new GitHub issues.
+
+## 1. Review Schedule
+* Check the issue tracker once per week.
+* Apply the `bug` or `enhancement` label based on the report.
+
+## 2. Duplicates and Clarification
+* Search for existing issues before triaging.
+* Ask for additional logs or reproduction steps if needed.
+
+## 3. Prioritisation
+* Tag high impact problems with `priority/high`.
+* Minor requests receive `priority/low`.
+
+## 4. Closing Issues
+* Close resolved issues with a short explanation and reference the commit or pull request.
+* If no response is received after 30 days, close as `stale`.
+
+Community contributions are encouraged. See [CONTRIBUTING.md](../CONTRIBUTING.md) for workflow details.

--- a/docs/LTS_POLICY.md
+++ b/docs/LTS_POLICY.md
@@ -1,0 +1,12 @@
+# Long-Term Support Policy
+
+> **Note**: All text is written in English. No multi-language versions are planned.
+
+Lego GPT is considered stable. The maintainers provide security patches and critical bug fixes only.
+
+## Support Window
+* The final tagged release receives security updates for **12 months**.
+* After the support window ends, no further patches will be released.
+
+## Community Forks
+Community maintainers are encouraged to fork the repository and continue development as needed. See [COMMUNITY_MAINTENANCE.md](COMMUNITY_MAINTENANCE.md) for guidance on submitting security fixes during the support period.

--- a/docs/PROJECT_BACKLOG.md
+++ b/docs/PROJECT_BACKLOG.md
@@ -94,11 +94,11 @@ The application is English-only. Multi-language user interfaces are out of scope
 | F-34 | **S**  | Advanced performance budgets                    | **Done** | Lighthouse CI checks accessibility & best practices |
 | F-35 | **S**  | Federated comment moderation                    | **Done** | Sync banned-user lists via new CLI |
 | F-36 | **S**  | Persistent offline queue                       | **Done** | Front-end and CLI store pending requests across sessions |
-
-
-
+| F-37 | **S**  | Issue triage guidelines                        | **Done** | Documented weekly review and labelling process |
+| F-38 | **S**  | Container vulnerability scanning               | **Done** | Trivy workflow scans on each push |
+| F-39 | **S**  | Long-term support policy                       | **Done** | Security updates provided for 12 months |
 ### Legend
 * **Pri** – MoSCoW priority (**M**ust, **S**hould, **C**ould, **W**on’t-Have-Now).
 * **Status** – Open / WIP / Blocked / Done.
 
-_Last updated 2025-08-07_
+_Last updated 2025-08-15_

--- a/docs/SPRINT_PLAN_LATEST.md
+++ b/docs/SPRINT_PLAN_LATEST.md
@@ -267,3 +267,12 @@ The feature set is now stable with an English-only interface and no plans for mu
 
 ## Sprint 85 – Documentation archive site (completed)
 * Instructions added for hosting the docs as a static site using MkDocs.
+
+## Sprint 86 – Issue triage guidelines (completed)
+* Documented the workflow for reviewing and labelling new issues.
+
+## Sprint 87 – Container vulnerability scanning (completed)
+* Added a Trivy GitHub Action that scans the repository on each push.
+
+## Sprint 88 – Long-term support policy (completed)
+* Created an LTS policy outlining the 12‑month security patch window.

--- a/docs/SPRINT_PLAN_NEXT.md
+++ b/docs/SPRINT_PLAN_NEXT.md
@@ -2,13 +2,13 @@
 
 > **Note**: The software remains English-only.
 
-The project is community driven. Future work focuses on long-term maintenance.
+The project is in long-term maintenance. Upcoming work focuses on automating routine tasks.
 
-## Sprint 86 – Issue triage guidelines
-* Document the workflow for reviewing and labelling new issues.
+## Sprint 89 – Automated stale issue cleanup
+* Configure a workflow to close issues that remain inactive for 30 days.
 
-## Sprint 87 – Container vulnerability scanning
-* Add a workflow that runs Trivy on each push.
+## Sprint 90 – Release sign-off checklist
+* Provide a short checklist for community maintainers performing a release.
 
-## Sprint 88 – Long-term support policy
-* Outline the security patch and support timeline.
+## Sprint 91 – Container image retention docs
+* Document how long published container images will remain available.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -7,5 +7,7 @@ nav:
   - Home: index.md
   - Architecture: ARCHITECTURE.md
   - Maintenance: COMMUNITY_MAINTENANCE.md
+  - Issue Triage: ISSUE_TRIAGE_GUIDE.md
+  - LTS Policy: LTS_POLICY.md
   - Dependency Versions: DEPENDENCY_VERSIONS.md
   - Backlog: PROJECT_BACKLOG.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "lego-gpt"
-version = "0.5.67"
+version = "0.5.68"
 requires-python = ">=3.11"
 
 [build-system]


### PR DESCRIPTION
## Summary
- document issue triage workflow and long-term support policy
- add Trivy container scanning action
- link new docs in README and mkdocs nav
- update project backlog and sprint plan
- bump version to 0.5.68

## Testing
- `./scripts/run_tests.sh` *(fails: pnpm missing offline packages)*