### PR TITLE
Fix Redis plan field in render.yaml

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -29,5 +29,5 @@ services:
   # ────────────────────────────────────────────────
   - type: redis
     name: lego-gpt-redis
-    tier: free        # Hobby tier – sleeps when idle
+    plan: free        # Hobby plan – sleeps when idle
     maxmemoryPolicy: allkeys-lru


### PR DESCRIPTION
## Summary
- fix Redis service blueprint by using `plan: free`

## Testing
- `ruff check .`
- `pytest -q`
