### PR TITLE
Fix Render blueprint env var and redis allow list

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -18,7 +18,6 @@ services:
       # Your auth secret – leave empty in Git, set in the Render UI
       - key: JWT_SECRET
         sync: false
-        value: ycQGGSqO3/JYGY96TLnC829sXFPHMW+OFIcx/OSL+gs=
       # Per-user request cap
       - key: RATE_LIMIT
         value: "10"
@@ -30,4 +29,6 @@ services:
   - type: redis
     name: lego-gpt-redis
     plan: free        # Hobby plan – sleeps when idle
+    ipAllowList:
+      - source: 0.0.0.0/0
     maxmemoryPolicy: allkeys-lru


### PR DESCRIPTION
## Summary
- remove value from JWT secret so Render blueprint doesn't specify value with `sync`
- add `ipAllowList` for Redis service to satisfy new schema

## Testing
- `bash scripts/run_tests.sh` *(fails: ERR_PNPM_NO_OFFLINE_META)*