### PR TITLE
Fix ortools pin

### DIFF
--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -5,7 +5,7 @@ requires-python = ">=3.11"
 dependencies = [
     "redis==5.0.0",
     "rq==1.16.0",
-    "ortools==9.10.0",
+    "ortools==9.10.4067",
     "websockets==12.0",
 ]
 

--- a/docs/DEPENDENCY_VERSIONS.md
+++ b/docs/DEPENDENCY_VERSIONS.md
@@ -8,7 +8,7 @@ The project is in maintenance mode. Versions are fixed to ensure reproducible bu
 |---------|---------|
 | redis | 5.0.0 |
 | rq | 1.16.0 |
-| ortools | 9.10.0 |
+| ortools | 9.10.4067 |
 | websockets | 12.0 |
 | fakeredis | 2.21.0 |
 | ruff | 0.4.0 |


### PR DESCRIPTION
## Summary
- bump ortools from 9.10.0 -> 9.10.4067

## Testing
- `./scripts/run_tests.sh` *(fails: ERR_PNPM_NO_OFFLINE_META)*