### PR TITLE
Fix TypeScript build

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -29,7 +29,8 @@
     "typescript": "5.8.3",
     "typescript-eslint": "8.30.1",
     "vite": "6.3.5",
-    "cypress": "13.7.3"
+    "cypress": "13.7.3",
+    "three": "0.160.0"
   },
   "packageManager": "pnpm@10.5.2"
 }

--- a/frontend/src/Analytics.tsx
+++ b/frontend/src/Analytics.tsx
@@ -2,11 +2,11 @@ import { useEffect, useState } from "react";
 import { API_BASE } from "./api/lego";
 
 interface Metrics {
-  [k: string]: number | Record<string, unknown>;
   history?: {
     token_usage: Array<[number, number]>;
     rate_limit_hits: Array<[number, number]>;
   };
+  [k: string]: number | Record<string, unknown> | undefined;
 }
 
 export default function Analytics({ onBack }: { onBack: () => void }) {

--- a/frontend/src/LDrawViewer.tsx
+++ b/frontend/src/LDrawViewer.tsx
@@ -24,14 +24,14 @@ export default function LDrawViewer({ url }: Props) {
     let animationId: number;
 
     async function init() {
-      const THREE = await import(
+      const THREE = (await import(
         /* @vite-ignore */
         "https://unpkg.com/three@0.160.0/build/three.module.js?module"
-      );
-      const { LDrawLoader } = await import(
+      )) as typeof import("three");
+      const { LDrawLoader } = (await import(
         /* @vite-ignore */
         "https://unpkg.com/three@0.160.0/examples/jsm/loaders/LDrawLoader.js?module"
-      );
+      )) as typeof import("three/examples/jsm/loaders/LDrawLoader.js");
 
       const scene = new THREE.Scene();
       const camera = new THREE.PerspectiveCamera(
@@ -43,17 +43,19 @@ export default function LDrawViewer({ url }: Props) {
       camera.position.set(200, 200, 200);
       camera.lookAt(0, 0, 0);
 
-      const { OrbitControls } = await import(
+      const { OrbitControls } = (await import(
         /* @vite-ignore */
         "https://unpkg.com/three@0.160.0/examples/jsm/controls/OrbitControls.js?module"
-      );
+      )) as typeof import("three/examples/jsm/controls/OrbitControls.js");
 
-      renderer = new THREE.WebGLRenderer({ antialias: true });
-      renderer.setSize(mountRef.current!.clientWidth, 400);
-      mountRef.current!.appendChild(renderer.domElement);
+      const localRenderer = new THREE.WebGLRenderer({ antialias: true });
+      localRenderer.setSize(mountRef.current!.clientWidth, 400);
+      mountRef.current!.appendChild(localRenderer.domElement);
+      renderer = localRenderer;
 
-      controls = new OrbitControls(camera, renderer.domElement);
-      controls.enableDamping = true;
+      const localControls = new OrbitControls(camera, localRenderer.domElement);
+      localControls.enableDamping = true;
+      controls = localControls;
 
       const loader = new LDrawLoader();
       loader.load(url, (group: unknown) => {
@@ -65,7 +67,9 @@ export default function LDrawViewer({ url }: Props) {
       function animate() {
         animationId = requestAnimationFrame(animate);
         controls?.update();
-        renderer!.render(scene, camera);
+        if (renderer) {
+          renderer.render(scene, camera);
+        }
       }
     }
 

--- a/frontend/src/three.d.ts
+++ b/frontend/src/three.d.ts
@@ -1,12 +1,11 @@
 declare module "https://unpkg.com/three@0.160.0/build/three.module.js?module" {
-  const value: unknown;
-  export = value;
+  export * from "three";
 }
 
 declare module "https://unpkg.com/three@0.160.0/examples/jsm/loaders/LDrawLoader.js?module" {
-  export const LDrawLoader: unknown;
+  export { LDrawLoader } from "three/examples/jsm/loaders/LDrawLoader.js";
 }
 
 declare module "https://unpkg.com/three@0.160.0/examples/jsm/controls/OrbitControls.js?module" {
-  export const OrbitControls: unknown;
+  export { OrbitControls } from "three/examples/jsm/controls/OrbitControls.js";
 }


### PR DESCRIPTION
## Summary
- provide proper typings for remote three.js modules
- update viewer component to use typed imports
- install three as a dev dependency

## Testing
- `pnpm --dir frontend install --frozen-lockfile` *(fails: lockfile out of date)*
- `pnpm --dir frontend run lint` *(fails: dependencies missing)*
