### PR TITLE
Fix Render build

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -35,7 +35,7 @@ services:
     runtime: static
     rootDir: frontend
     buildCommand: |
-      pnpm install --frozen-lockfile
+      pnpm install --no-frozen-lockfile
       pnpm run build
     staticPublishPath: dist
     branch: main


### PR DESCRIPTION
## Summary
- relax frozen lockfile in `render.yaml` to allow deployment when `pnpm-lock.yaml` isn't fully up to date

## Testing
- `python -m unittest discover -v`
