### PR TITLE
Fix Render deployment by aligning package.json with lockfile

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -29,8 +29,7 @@
     "typescript": "5.8.3",
     "typescript-eslint": "8.30.1",
     "vite": "6.3.5",
-    "cypress": "13.7.3",
-    "three": "0.160.0"
+    "cypress": "13.7.3"
   },
   "packageManager": "pnpm@10.5.2"
 }


### PR DESCRIPTION
## Summary
- remove unused `three` entry from `frontend/package.json` to match pnpm-lock

## Testing
- `./scripts/run_tests.sh` *(fails to install front-end packages due to offline environment but all Python tests pass)*