### PR TITLE
Fix missing three dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [0.5.70] – 2025-05-30
+### Fixed
+- Restored the `three` dependency so the front-end builds correctly on Render.
+
 ## [0.5.69] – 2025-05-28
 ### Changed
 * Backend package version bumped to 0.5.69.

--- a/backend/__init__.py
+++ b/backend/__init__.py
@@ -22,7 +22,7 @@ except Exception:  # pragma: no cover - ignore if missing
 try:  # pragma: no cover - during editable installs
     __version__ = version("lego-gpt-backend")
 except PackageNotFoundError:  # pragma: no cover - fallback for tests
-    __version__ = "0.5.69"
+    __version__ = "0.5.70"
 
 PACKAGE_DIR = Path(__file__).parent
 REDIS_URL = os.getenv("REDIS_URL", "redis://localhost:6379/0")

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "lego-gpt-backend"
-version = "0.5.69"
+version = "0.5.70"
 requires-python = ">=3.11"
 dependencies = [
     "redis==5.0.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -13,7 +13,8 @@
   },
   "dependencies": {
     "react": "19.1.0",
-    "react-dom": "19.1.0"
+    "react-dom": "19.1.0",
+    "three": "0.160.0"
   },
   "devDependencies": {
     "@eslint/js": "9.25.0",

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -14,6 +14,9 @@ importers:
       react-dom:
         specifier: 19.1.0
         version: 19.1.0(react@19.1.0)
+      three:
+        specifier: 0.160.0
+        version: 0.160.0
     devDependencies:
       '@eslint/js':
         specifier: 9.25.0
@@ -3169,6 +3172,8 @@ snapshots:
   throttleit@1.0.1: {}
 
   through@2.3.8: {}
+
+  three@0.160.0: {}
 
   tinyglobby@0.2.14:
     dependencies:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "lego-gpt"
-version = "0.5.69"
+version = "0.5.70"
 requires-python = ">=3.11"
 
 [build-system]


### PR DESCRIPTION
## Summary
- include `three` as a dependency so the LDraw viewer compiles
- bump package version to 0.5.70

## Testing
- `ruff check backend detector`
- `pnpm -C frontend install` *(fails: Cannot use 'in' operator to search for 'directory' in undefined)*
- `pnpm -C frontend run build` *(fails to find packages)*