### PR TITLE
Update sprint docs for Epic E-07

### DIFF
--- a/docs/PROJECT_BACKLOG.md
+++ b/docs/PROJECT_BACKLOG.md
@@ -97,8 +97,9 @@ The application is English-only. Multi-language user interfaces are out of scope
 | F-37 | **S**  | Issue triage guidelines                        | **Done** | Documented weekly review and labelling process |
 | F-38 | **S**  | Container vulnerability scanning               | **Open** | Planned Trivy integration deferred |
 | F-39 | **S**  | Long-term support policy                       | **Done** | Security updates provided for 12 months |
+| F-40 | **M**  | FastAPI gateway refactor (Epic E‑07)           | **Open** | Sprints 88‑93 migrate the gateway to FastAPI |
 ### Legend
 * **Pri** – MoSCoW priority (**M**ust, **S**hould, **C**ould, **W**on’t-Have-Now).
 * **Status** – Open / WIP / Blocked / Done.
 
-_Last updated 2025-08-15_
+_Last updated 2025-08-17_

--- a/docs/SPRINT_PLAN_LATEST.md
+++ b/docs/SPRINT_PLAN_LATEST.md
@@ -273,3 +273,21 @@ The feature set is now stable with an English-only interface and no plans for mu
 
 ## Sprint 87 – Long-term support policy (completed)
 * Created an LTS policy outlining the 12‑month security patch window.
+
+## Sprint 88 – FastAPI scaffold
+* Add `backend/api.py` with a `/health` endpoint and local dev command.
+
+## Sprint 89 – GET route migration
+* Move `/metrics`, `/metrics_prom` and `/history` routes with tests.
+
+## Sprint 90 – POST route migration
+* Refactor `/generate` and `/detect_inventory` endpoints for FastAPI.
+
+## Sprint 91 – Middleware & security
+* Enable CORS, bearer-token auth stub and rate limiting.
+
+## Sprint 92 – CI/CD & Render rollout
+* Update `render.yaml` and deploy using a blue/green strategy.
+
+## Sprint 93 – Docs & monitoring
+* Polish `/docs`, expose Prometheus metrics and update the README.

--- a/docs/SPRINT_PLAN_NEXT.md
+++ b/docs/SPRINT_PLAN_NEXT.md
@@ -2,13 +2,22 @@
 
 > **Note**: The software remains English-only.
 
-The project is in long-term maintenance. Upcoming work focuses on automating routine tasks.
+The next six sprints implement **Epic E-07 – FastAPI Gateway Refactor**.
 
-## Sprint 88 – Automated stale issue cleanup
-* Configure a workflow to close issues that remain inactive for 30 days.
+## Sprint 88 – FastAPI scaffold
+* Add `backend/api.py` with a `/health` route and dev command.
 
-## Sprint 89 – Release sign-off checklist
-* Provide a short checklist for community maintainers performing a release.
+## Sprint 89 – GET route migration
+* Move `/metrics`, `/metrics_prom` and `/history` with tests.
 
-## Sprint 90 – Container image retention docs
-* Document how long published container images will remain available.
+## Sprint 90 – POST route migration
+* Refactor `/generate` and `/detect_inventory` for FastAPI.
+
+## Sprint 91 – Middleware & security
+* Enable CORS, bearer-token auth stub and rate limiting.
+
+## Sprint 92 – CI/CD & Render rollout
+* Update `render.yaml` and deploy with blue/green strategy.
+
+## Sprint 93 – Docs & monitoring
+* Polish `/docs`, expose Prometheus metrics and update README.


### PR DESCRIPTION
## Summary
- add FastAPI refactor to project backlog
- document six new sprints for Epic E-07 in latest and next sprint plans

## Testing
- `./scripts/run_tests.sh` *(fails: package missing, offline)*

------
https://chatgpt.com/codex/tasks/task_e_6839f478fa64832785eff6824d57dd34