### PR TITLE
Implement Render deployment improvements

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,8 +21,10 @@ jobs:
         with:
           python-version: "3.12"
 
-      - name: Install ruff and coverage
-        run: pip install ruff coverage
+      - name: Install Python dependencies
+        run: |
+          pip install ruff coverage
+          pip install -e ./backend[test]
 
       - name: Run ruff
         run: ruff check backend detector
@@ -31,6 +33,10 @@ jobs:
         run: |
           coverage run -m unittest discover -v
           coverage xml
+
+      - name: Smoke test FastAPI app
+        run: |
+          timeout 5s uvicorn backend.api:app --port 9999 --lifespan on --log-level warning
 
       - name: Upload coverage
         uses: codecov/codecov-action@v3

--- a/README.md
+++ b/README.md
@@ -342,6 +342,20 @@ environment variable when running the detector worker. See
 [`docs/DETECTOR_DATASET.md`](docs/DETECTOR_DATASET.md) for the required dataset
 layout.
 
+#### Render quick-start
+
+Deploy the API and PWA on [Render](https://render.com) using the bundled
+`render.yaml` blueprint:
+
+```bash
+render blueprint apply render.yaml
+```
+
+The configuration spins up a Redis instance, a Python web service running
+`uvicorn api:app`, and a static site for the front-end build. Update any
+environment variables in the Render dashboard or via `envVarGroups` as needed.
+
+
 > **Prerequisites**
 > * Python 3.11+
 > * Node.js 20+

--- a/backend/api.py
+++ b/backend/api.py
@@ -1,7 +1,11 @@
 """Minimal API functions for offline use."""
 from pathlib import Path
-from backend.inference import generate
+import os
 from redis import Redis
+from fastapi import FastAPI, HTTPException
+from fastapi.middleware.cors import CORSMiddleware
+from starlette.concurrency import run_in_threadpool
+from backend.inference import generate
 from backend import __version__, STATIC_ROOT, STATIC_URL_PREFIX, REDIS_URL
 from backend.storage import maybe_upload_assets
 
@@ -64,3 +68,18 @@ def generate_lego_model(
         "brick_counts": brick_counts,
         "instructions_url": pdf_url,
     }
+
+
+app = FastAPI(title="Lego-GPT API")
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=os.getenv("CORS_ORIGINS", "*").split(","),
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
+
+
+@app.get("/health")
+async def health_route() -> dict:
+    return await run_in_threadpool(health)
+

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -7,6 +7,9 @@ dependencies = [
     "rq==1.16.0",
     "ortools==9.10.4067",
     "websockets==12.0",
+    "fastapi==0.97.0",
+    "uvicorn[standard]==0.27.0.post1",
+    "slowapi==0.1.9",
 ]
 
 [project.optional-dependencies]

--- a/docs/DEPENDENCY_VERSIONS.md
+++ b/docs/DEPENDENCY_VERSIONS.md
@@ -10,6 +10,9 @@ The project is in maintenance mode. Versions are fixed to ensure reproducible bu
 | rq | 1.16.0 |
 | ortools | 9.10.4067 |
 | websockets | 12.0 |
+| fastapi | 0.97.0 |
+| uvicorn | 0.27.0.post1 |
+| slowapi | 0.1.9 |
 | fakeredis | 2.21.0 |
 | ruff | 0.4.0 |
 | coverage | 7.0.0 |

--- a/docs/sprint-framework/epic-E07-fastapi-refactor.md
+++ b/docs/sprint-framework/epic-E07-fastapi-refactor.md
@@ -57,11 +57,13 @@ slowapi` |
 
 ## CI / Render adjustments
 
-* **render.yaml** (service *lego‑gpt‑api*):  
+* **render.yaml** (service *lego‑gpt‑api*):
   ```yaml
   rootDir: backend
   startCommand: uvicorn api:app --host 0.0.0.0 --port $PORT
   ```
+  A second service `lego-gpt-api-blue` is defined but kept disabled to allow
+  blue/green rollouts.
 * **.github/workflows/ci.yml**:  
   * run `pytest`  
   * run smoke test: `uvicorn backend.api:app --port 9999 --lifespan on --log-level warning` for 5 s.

--- a/render.yaml
+++ b/render.yaml
@@ -2,9 +2,11 @@
 services:
   # ────────────────────────────────────────────────
   - type: web
-    name: lego-gpt-api
-    env: docker
-    dockerfilePath: backend/Dockerfile.cpu
+    name: lego-gpt-api-green
+    runtime: python
+    rootDir: backend
+    buildCommand: pip install -e .
+    startCommand: uvicorn api:app --host 0.0.0.0 --port $PORT
     autoDeploy: true
     branch: main
     plan: standard            # 2 GB RAM / 1 vCPU
@@ -15,6 +17,28 @@ services:
           name: lego-gpt-redis
           property: connectionString
       - key: JWT_SECRET        # removed “sync: false”
+        value: ycQGGSqO3/JYGY96TLnC829sXFPHMW+OFIcx/OSL+gs=
+      - key: RATE_LIMIT
+        value: "10"
+      - key: CORS_ORIGINS
+        value: "http://localhost:5173,https://lego-gpt.onrender.com"
+
+  - type: web
+    name: lego-gpt-api-blue
+    runtime: python
+    rootDir: backend
+    buildCommand: pip install -e .
+    startCommand: uvicorn api:app --host 0.0.0.0 --port $PORT
+    autoDeploy: false
+    branch: main
+    plan: standard
+    envVars:
+      - fromService:
+          type: redis
+          name: lego-gpt-redis
+          property: connectionString
+        key: REDIS_URL
+      - key: JWT_SECRET
         value: ycQGGSqO3/JYGY96TLnC829sXFPHMW+OFIcx/OSL+gs=
       - key: RATE_LIMIT
         value: "10"


### PR DESCRIPTION
## Summary
- add Render quick-start docs
- configure blue/green Python web services in `render.yaml`
- expose FastAPI app and CORS handling
- install backend deps and run a smoke test in CI
- document FastAPI dependencies

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6839f7018adc8327b81f864b9e2d7a38