### PR TITLE
Fix Render start path

### DIFF
--- a/README.md
+++ b/README.md
@@ -352,8 +352,13 @@ render blueprint apply render.yaml
 ```
 
 The configuration spins up a Redis instance, a Python web service running
-`uvicorn api:app`, and a static site for the front-end build. Update any
+`uvicorn backend.api:app`, and a static site for the front-end build. Update any
 environment variables in the Render dashboard or via `envVarGroups` as needed.
+
+The blueprint defines two API services—`lego-gpt-api-green` and
+`lego-gpt-api-blue`. Only the green service is active by default. The blue
+service stays disabled until you use it for a blue/green rollout, so it may show
+as a failed or pending deploy in the Render dashboard.
 
 
 > **Prerequisites**

--- a/docs/sprint-framework/epic-E07-fastapi-refactor.md
+++ b/docs/sprint-framework/epic-E07-fastapi-refactor.md
@@ -59,8 +59,9 @@ slowapi` |
 
 * **render.yaml** (service *lego‑gpt‑api*):
   ```yaml
-  rootDir: backend
-  startCommand: uvicorn api:app --host 0.0.0.0 --port $PORT
+  rootDir: .
+  buildCommand: pip install -e backend
+  startCommand: uvicorn backend.api:app --host 0.0.0.0 --port $PORT
   ```
   A second service `lego-gpt-api-blue` is defined but kept disabled to allow
   blue/green rollouts.

--- a/render.yaml
+++ b/render.yaml
@@ -4,9 +4,9 @@ services:
   - type: web
     name: lego-gpt-api-green
     runtime: python
-    rootDir: backend
-    buildCommand: pip install -e .
-    startCommand: uvicorn api:app --host 0.0.0.0 --port $PORT
+    rootDir: .
+    buildCommand: pip install -e backend
+    startCommand: uvicorn backend.api:app --host 0.0.0.0 --port $PORT
     autoDeploy: true
     branch: main
     plan: standard            # 2 GB RAM / 1 vCPU
@@ -26,9 +26,9 @@ services:
   - type: web
     name: lego-gpt-api-blue
     runtime: python
-    rootDir: backend
-    buildCommand: pip install -e .
-    startCommand: uvicorn api:app --host 0.0.0.0 --port $PORT
+    rootDir: .
+    buildCommand: pip install -e backend
+    startCommand: uvicorn backend.api:app --host 0.0.0.0 --port $PORT
     autoDeploy: false
     branch: main
     plan: standard


### PR DESCRIPTION
## Summary
- fix Render services to start from repo root
- update Render start instructions in docs

## Testing
- `./scripts/run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_683a2c0607408327aae10383e5e4a927