### PR TITLE
Add dev script for FastAPI

### DIFF
--- a/README.md
+++ b/README.md
@@ -277,6 +277,18 @@ The API will be available at http://localhost:8000/health.
 The `/health` endpoint responds with `{ "ok": true, "version": "x.y.z" }` so you
 can verify the backend version.
 
+### FastAPI dev helper
+
+For a lighter setup during development, run `backend/dev.sh` to launch the API
+with auto-reload enabled:
+
+```bash
+./backend/dev.sh
+```
+
+The script starts `uvicorn` on <http://localhost:8000> and watches for code
+changes.
+
 ### Production Docker Images
 
 Release tags trigger a workflow that builds CPU and GPU images and publishes

--- a/backend/dev.sh
+++ b/backend/dev.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
 
-# Simple dev helper
-python gateway.py
+# Simple dev helper running the FastAPI app
+set -euo pipefail
+uvicorn backend.api:app --reload --host 0.0.0.0 --port 8000


### PR DESCRIPTION
## Summary
- start FastAPI with auto-reload via `backend/dev.sh`
- document the helper script in README

## Testing
- `./scripts/run_tests.sh` *(fails: pnpm store missing in offline mode)*


------
https://chatgpt.com/codex/tasks/task_e_683a4c6ea72c8327a16b08ed46ded2e0