### PR TITLE
Finalize FastAPI refactor and Render docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## [0.5.71] – 2025-05-31
+### Added
+- FastAPI routes for `/generate`, `/detect_inventory`, `/metrics`,
+  `/metrics_prom` and `/history` with token-based auth.
+- Prometheus metrics endpoint exposed in Render deployment docs.
+### Changed
+- Backend package version bumped to 0.5.71.
+
 ## [0.5.70] – 2025-05-30
 ### Fixed
 - Restored the `three` dependency so the front-end builds correctly on Render.

--- a/README.md
+++ b/README.md
@@ -374,6 +374,9 @@ The blueprint defines two API services—`lego-gpt-api-green` and
 service stays disabled until you use it for a blue/green rollout, so it may show
 as a failed or pending deploy in the Render dashboard.
 
+Once deployed, visit `/docs` on the API service URL to explore the OpenAPI
+documentation. Admin users can fetch `/metrics_prom` for Prometheus scraping.
+
 
 > **Prerequisites**
 > * Python 3.11+

--- a/backend/__init__.py
+++ b/backend/__init__.py
@@ -22,7 +22,7 @@ except Exception:  # pragma: no cover - ignore if missing
 try:  # pragma: no cover - during editable installs
     __version__ = version("lego-gpt-backend")
 except PackageNotFoundError:  # pragma: no cover - fallback for tests
-    __version__ = "0.5.70"
+    __version__ = "0.5.71"
 
 PACKAGE_DIR = Path(__file__).parent
 REDIS_URL = os.getenv("REDIS_URL", "redis://localhost:6379/0")

--- a/backend/api.py
+++ b/backend/api.py
@@ -1,13 +1,30 @@
 """Minimal API functions for offline use."""
-from pathlib import Path
+from __future__ import annotations
+
+import json
 import os
+import time
+
 from redis import Redis
-from fastapi import FastAPI
+from rq import Queue, Retry, Job
+from fastapi import (
+    FastAPI,
+    Depends,
+    HTTPException,
+    Response,
+    status,
+)
+from pydantic import BaseModel
+from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
 from fastapi.middleware.cors import CORSMiddleware
 from starlette.concurrency import run_in_threadpool
-from backend.inference import generate
-from backend import __version__, STATIC_ROOT, STATIC_URL_PREFIX, REDIS_URL
-from backend.storage import maybe_upload_assets
+
+from backend import (
+    __version__,
+    REDIS_URL,
+    HISTORY_ROOT,
+)
+from backend.auth import decode as decode_jwt
 
 
 def health() -> dict:
@@ -22,52 +39,88 @@ def health() -> dict:
     return {"ok": redis_ok, "version": __version__, "redis": redis_ok}
 
 
-def generate_lego_model(
-    prompt: str, seed: int = 42, inventory_filter: dict[str, int] | None = None
-) -> dict:
-    """Run the model and return URLs for the generated preview and models."""
-    png_path, ldr_path, gltf_path, pdf_path, brick_counts = generate(
-        prompt, seed, inventory_filter
-    )
 
-    paths = [Path(png_path)]
-    if ldr_path:
-        paths.append(Path(ldr_path))
-    if gltf_path:
-        paths.append(Path(gltf_path))
-    if pdf_path:
-        paths.append(Path(pdf_path))
 
-    urls, uploaded = maybe_upload_assets(paths)
-    pdf_url = None
-    if uploaded:
-        url_iter = iter(urls)
-        png_url = next(url_iter)
-        ldr_url = next(url_iter) if ldr_path else None
-        gltf_url = next(url_iter) if gltf_path else None
-        pdf_url = next(url_iter) if pdf_path else None
-    else:
-        rel_png = Path(png_path).resolve().relative_to(STATIC_ROOT.parent)
-        png_url = f"{STATIC_URL_PREFIX}/{rel_png.parent.name}/preview.png"
-        ldr_url = None
-        gltf_url = None
-        if ldr_path:
-            rel_ldr = Path(ldr_path).resolve().relative_to(STATIC_ROOT.parent)
-            ldr_url = f"{STATIC_URL_PREFIX}/{rel_ldr.parent.name}/model.ldr"
-        if gltf_path:
-            rel_gltf = Path(gltf_path).resolve().relative_to(STATIC_ROOT.parent)
-            gltf_url = f"{STATIC_URL_PREFIX}/{rel_gltf.parent.name}/model.gltf"
-        if pdf_path:
-            rel_pdf = Path(pdf_path).resolve().relative_to(STATIC_ROOT.parent)
-            pdf_url = f"{STATIC_URL_PREFIX}/{rel_pdf.parent.name}/instructions.pdf"
+JWT_SECRET = os.getenv("JWT_SECRET", "secret")
+RATE_LIMIT = int(os.getenv("RATE_LIMIT", "10"))
 
-    return {
-        "png_url": png_url,
-        "ldr_url": ldr_url,
-        "gltf_url": gltf_url,
-        "brick_counts": brick_counts,
-        "instructions_url": pdf_url,
-    }
+redis_conn = Redis.from_url(REDIS_URL)
+QUEUE_NAME = os.getenv("QUEUE_NAME", "legogpt")
+queue = Queue(QUEUE_NAME, connection=redis_conn)
+DEFAULT_RETRY = Retry(max=3, interval=[10, 30, 60])
+
+_TOKEN_USAGE: dict[str, tuple[int, int]] = {}
+
+METRICS = {
+    "generate_requests": 0,
+    "detect_requests": 0,
+    "example_submissions": 0,
+    "example_reports": 0,
+    "token_usage": 0,
+    "rate_limit_hits": 0,
+}
+
+METRICS_HISTORY: dict[str, dict[int, int]] = {
+    "token_usage": {},
+    "rate_limit_hits": {},
+}
+
+
+def _prometheus_metrics() -> str:
+    lines = []
+    for key, val in METRICS.items():
+        lines.append(f"# TYPE lego_gpt_{key} counter")
+        lines.append(f"lego_gpt_{key} {val}")
+    return "\n".join(lines) + "\n"
+
+
+def _record_history(key: str) -> None:
+    now_min = int(time.time() // 60)
+    hist = METRICS_HISTORY.setdefault(key, {})
+    hist[now_min] = hist.get(now_min, 0) + 1
+    for ts in list(hist):
+        if now_min - ts > 59:
+            del hist[ts]
+
+
+bearer = HTTPBearer(auto_error=False)
+
+
+def _rate_limit(token: str) -> None:
+    now = int(time.time())
+    window = now // 60
+    count, win = _TOKEN_USAGE.get(token, (0, window))
+    if win != window:
+        count = 0
+        win = window
+    if count >= RATE_LIMIT:
+        METRICS["rate_limit_hits"] += 1
+        _record_history("rate_limit_hits")
+        raise HTTPException(status_code=429, detail="rate_limit")
+    _TOKEN_USAGE[token] = (count + 1, win)
+
+
+async def _auth(
+    credentials: HTTPAuthorizationCredentials | None = Depends(bearer),
+) -> tuple[dict, str]:
+    if credentials is None:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED)
+    token = credentials.credentials
+    try:
+        payload = decode_jwt(token, JWT_SECRET)
+    except Exception:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED)
+    _rate_limit(token)
+    METRICS["token_usage"] += 1
+    _record_history("token_usage")
+    return payload, token
+
+
+def _admin(payload_and_token: tuple[dict, str] = Depends(_auth)) -> dict:
+    payload, _ = payload_and_token
+    if payload.get("role") != "admin":
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED)
+    return payload
 
 
 app = FastAPI(title="Lego-GPT API")
@@ -82,4 +135,128 @@ app.add_middleware(
 @app.get("/health")
 async def health_route() -> dict:
     return await run_in_threadpool(health)
+
+
+class GenerateRequest(BaseModel):
+    prompt: str = ""
+    seed: int | None = 42
+    inventory_filter: dict[str, int] | None = None
+
+
+class ImageRequest(BaseModel):
+    image: str
+
+
+@app.post("/generate")
+async def generate_route(
+    req: GenerateRequest,
+    auth: tuple[dict, str] = Depends(_auth),
+) -> dict:
+    payload, _token = auth
+    from backend.worker import generate_job  # imported here to avoid circular dependency
+
+    job = await run_in_threadpool(
+        queue.enqueue,
+        generate_job,
+        req.prompt,
+        req.seed or 42,
+        req.inventory_filter,
+        retry=DEFAULT_RETRY,
+    )
+    job.meta["user"] = payload.get("sub", "user")
+    job.meta["prompt"] = req.prompt
+    job.meta["seed"] = req.seed or 42
+    job.save_meta()
+    METRICS["generate_requests"] += 1
+    return {"job_id": job.id}
+
+
+@app.get("/generate/{job_id}")
+async def generate_result_route(
+    job_id: str,
+    auth: tuple[dict, str] = Depends(_auth),
+) -> Response:
+    try:
+        job = Job.fetch(job_id, connection=redis_conn)
+    except Exception:
+        raise HTTPException(status_code=404)
+    if job.is_finished:
+        return job.result
+    if job.is_failed:
+        raise HTTPException(status_code=500, detail="Job failed")
+    return Response(status_code=202)
+
+
+@app.post("/detect_inventory")
+async def detect_inventory_route(
+    req: ImageRequest,
+    auth: tuple[dict, str] = Depends(_auth),
+) -> dict:
+    payload, _token = auth
+    from backend.worker import detect_job  # imported here to avoid circular dependency
+
+    job = await run_in_threadpool(
+        queue.enqueue,
+        detect_job,
+        req.image,
+        retry=DEFAULT_RETRY,
+    )
+    job.meta["user"] = payload.get("sub", "user")
+    job.save_meta()
+    METRICS["detect_requests"] += 1
+    return {"job_id": job.id}
+
+
+@app.get("/detect_inventory/{job_id}")
+async def detect_inventory_result_route(
+    job_id: str,
+    auth: tuple[dict, str] = Depends(_auth),
+) -> Response:
+    try:
+        job = Job.fetch(job_id, connection=redis_conn)
+    except Exception:
+        raise HTTPException(status_code=404)
+    if job.is_finished:
+        result = job.result
+        user = job.meta.get("user")
+        if user:
+            HISTORY_ROOT.mkdir(parents=True, exist_ok=True)
+            file_path = HISTORY_ROOT / f"{user}.jsonl"
+            record = {
+                "prompt": job.meta.get("prompt", ""),
+                "seed": job.meta.get("seed", 42),
+                "result": result,
+                "ts": int(time.time()),
+            }
+            with open(file_path, "a") as fh:
+                fh.write(json.dumps(record) + "\n")
+        return result
+    if job.is_failed:
+        raise HTTPException(status_code=500, detail="Job failed")
+    return Response(status_code=202)
+
+
+@app.get("/metrics")
+async def metrics_route(admin: dict = Depends(_admin)) -> dict:
+    payload = dict(METRICS)
+    payload["history"] = {k: sorted(v.items()) for k, v in METRICS_HISTORY.items()}
+    return payload
+
+
+@app.get("/metrics_prom")
+async def metrics_prom_route(admin: dict = Depends(_admin)) -> Response:
+    data = await run_in_threadpool(_prometheus_metrics)
+    return Response(content=data, media_type="text/plain; version=0.0.4")
+
+
+@app.get("/history")
+async def history_route(auth: tuple[dict, str] = Depends(_auth)) -> dict:
+    payload, _token = auth
+    user = payload.get("sub", "user")
+    file_path = HISTORY_ROOT / f"{user}.jsonl"
+    if file_path.is_file():
+        entries = [json.loads(line) for line in file_path.read_text().splitlines()]
+    else:
+        entries = []
+    return {"history": entries}
 

--- a/backend/generation.py
+++ b/backend/generation.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+from pathlib import Path
+from backend.inference import generate
+from backend import STATIC_ROOT, STATIC_URL_PREFIX
+from backend.storage import maybe_upload_assets
+
+
+def generate_lego_model(
+    prompt: str, seed: int = 42, inventory_filter: dict[str, int] | None = None
+) -> dict:
+    """Run the model and return URLs for the generated preview and models."""
+    png_path, ldr_path, gltf_path, pdf_path, brick_counts = generate(
+        prompt, seed, inventory_filter
+    )
+
+    paths = [Path(png_path)]
+    if ldr_path:
+        paths.append(Path(ldr_path))
+    if gltf_path:
+        paths.append(Path(gltf_path))
+    if pdf_path:
+        paths.append(Path(pdf_path))
+
+    urls, uploaded = maybe_upload_assets(paths)
+    pdf_url = None
+    if uploaded:
+        url_iter = iter(urls)
+        png_url = next(url_iter)
+        ldr_url = next(url_iter) if ldr_path else None
+        gltf_url = next(url_iter) if gltf_path else None
+        pdf_url = next(url_iter) if pdf_path else None
+    else:
+        rel_png = Path(png_path).resolve().relative_to(STATIC_ROOT.parent)
+        png_url = f"{STATIC_URL_PREFIX}/{rel_png.parent.name}/preview.png"
+        ldr_url = None
+        gltf_url = None
+        if ldr_path:
+            rel_ldr = Path(ldr_path).resolve().relative_to(STATIC_ROOT.parent)
+            ldr_url = f"{STATIC_URL_PREFIX}/{rel_ldr.parent.name}/model.ldr"
+        if gltf_path:
+            rel_gltf = Path(gltf_path).resolve().relative_to(STATIC_ROOT.parent)
+            gltf_url = f"{STATIC_URL_PREFIX}/{rel_gltf.parent.name}/model.gltf"
+        if pdf_path:
+            rel_pdf = Path(pdf_path).resolve().relative_to(STATIC_ROOT.parent)
+            pdf_url = f"{STATIC_URL_PREFIX}/{rel_pdf.parent.name}/instructions.pdf"
+
+    return {
+        "png_url": png_url,
+        "ldr_url": ldr_url,
+        "gltf_url": gltf_url,
+        "brick_counts": brick_counts,
+        "instructions_url": pdf_url,
+    }

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "lego-gpt-backend"
-version = "0.5.70"
+version = "0.5.71"
 requires-python = ">=3.11"
 dependencies = [
     "redis==5.0.0",

--- a/backend/tests/test_generate.py
+++ b/backend/tests/test_generate.py
@@ -12,11 +12,11 @@ for p in (project_root, vendor_root):
         sys.path.insert(0, str(p))
 os.environ["PYTHONPATH"] = str(project_root)
 
-from backend.api import generate_lego_model  # noqa: E402
+from backend.generation import generate_lego_model  # noqa: E402
 
 
 class GenerateTests(unittest.TestCase):
-    @patch("backend.api.generate")
+    @patch("backend.generation.generate")
     def test_generate_endpoint(self, mock_generate):
         mock_generate.return_value = (
             "backend/static/x/preview.png",

--- a/backend/worker.py
+++ b/backend/worker.py
@@ -4,7 +4,7 @@ from redis import Redis
 from rq import Connection, Worker
 from backend.logging_config import setup_logging
 from backend.config import apply_yaml_config
-from backend.api import generate_lego_model
+from backend.generation import generate_lego_model
 from backend.detector import detect_inventory
 from backend import __version__
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -96,7 +96,7 @@ _Last updated 2025-07-28_
 
 ## Brick‑Detector Micro‑service (new in v0.5.0)
 
-Adds a YOLOv8‑based computer‑vision worker that converts user‑supplied photos into an inventory map `{ part_id: count }`. The gateway exposes `/detect_inventory`, and the PWA includes an `InventoryScanner` component (hook `useDetectInventory`) so users can upload one or more photos, review the detected parts list and generate a model constrained to their bricks. Results from multiple photos are merged into a single inventory file.
+Adds a YOLOv8‑based computer‑vision worker that converts user‑supplied photos into an inventory map `{ part_id: count }`. The FastAPI server exposes `/detect_inventory`, and the PWA includes an `InventoryScanner` component (hook `useDetectInventory`) so users can upload one or more photos, review the detected parts list and generate a model constrained to their bricks. Results from multiple photos are merged into a single inventory file.
 
 The API validates that the `image` field contains a valid base64 string and
 returns HTTP 400 for malformed data.

--- a/docs/PROJECT_BACKLOG.md
+++ b/docs/PROJECT_BACKLOG.md
@@ -97,7 +97,7 @@ The application is English-only. Multi-language user interfaces are out of scope
 | F-37 | **S**  | Issue triage guidelines                        | **Done** | Documented weekly review and labelling process |
 | F-38 | **S**  | Container vulnerability scanning               | **Open** | Planned Trivy integration deferred |
 | F-39 | **S**  | Long-term support policy                       | **Done** | Security updates provided for 12 months |
-| F-40 | **M**  | FastAPI gateway refactor (Epic E‑07)           | **Open** | Sprints 88‑93 migrate the gateway to FastAPI |
+| F-40 | **M**  | FastAPI gateway refactor (Epic E‑07)           | **Done** | Sprints 88‑93 migrated the gateway to FastAPI |
 ### Legend
 * **Pri** – MoSCoW priority (**M**ust, **S**hould, **C**ould, **W**on’t-Have-Now).
 * **Status** – Open / WIP / Blocked / Done.

--- a/docs/SPRINT_PLAN_LATEST.md
+++ b/docs/SPRINT_PLAN_LATEST.md
@@ -290,5 +290,5 @@ The feature set is now stable with an English-only interface and no plans for mu
 * Updated `render.yaml` with Python 3.11 and `/health` checks.
 * Added a blue/green API pair for safe deploys.
 
-## Sprint 93 – Docs & monitoring
-* Polish `/docs`, expose Prometheus metrics and update the README.
+## Sprint 93 – Docs & monitoring (completed)
+* Polished `/docs`, exposed Prometheus metrics and updated the README.

--- a/docs/SPRINT_PLAN_NEXT.md
+++ b/docs/SPRINT_PLAN_NEXT.md
@@ -2,7 +2,9 @@
 
 > **Note**: The software remains English-only.
 
-The final step of **Epic E-07 – FastAPI Gateway Refactor** is underway.
+The final step of **Epic E-07 – FastAPI Gateway Refactor** has concluded.
 
-## Sprint 93 – Docs & monitoring
-* Polish `/docs`, expose Prometheus metrics and update README.
+## Sprint 93 – Docs & monitoring (completed)
+* Polished `/docs`, exposed Prometheus metrics and updated README.
+
+No further sprints are scheduled; the project is ready for maintenance mode.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "lego-gpt"
-version = "0.5.70"
+version = "0.5.71"
 requires-python = ">=3.11"
 
 [build-system]


### PR DESCRIPTION
## Summary
- complete FastAPI rollout with auth, rate limit and metrics
- add `/generate`, `/detect_inventory`, `/metrics`, `/metrics_prom` and `/history`
- document Render deployment and Prometheus scraping
- mark sprint 93 complete and update backlog
- bump backend version to 0.5.71

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683a527331f08327acec5656162e9145