### PR TITLE
Fix RQ Job import

### DIFF
--- a/backend/api.py
+++ b/backend/api.py
@@ -6,7 +6,11 @@ import os
 import time
 
 from redis import Redis
-from rq import Queue, Retry, Job
+from rq import Queue, Retry
+try:
+    from rq.job import Job
+except Exception:  # pragma: no cover - fallback for older/stub versions
+    from rq import Job
 from fastapi import (
     FastAPI,
     Depends,


### PR DESCRIPTION
## Summary
- ensure compatibility with recent `rq` releases by importing `Job` from `rq.job`

## Testing
- `./scripts/run_tests.sh` *(fails: ERR_PNPM_NO_OFFLINE_TARBALL)*

------
https://chatgpt.com/codex/tasks/task_e_683a567473ac8327a35895b948163338