### PR TITLE
Add Render deployment docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -377,6 +377,10 @@ as a failed or pending deploy in the Render dashboard.
 Once deployed, visit `/docs` on the API service URL to explore the OpenAPI
 documentation. Admin users can fetch `/metrics_prom` for Prometheus scraping.
 
+See [docs/RENDER_DEPLOYMENT.md](docs/RENDER_DEPLOYMENT.md) for detailed
+instructions on managing the Render services and performing blue/green
+deployments.
+
 
 > **Prerequisites**
 > * Python 3.11+

--- a/docs/RENDER_DEPLOYMENT.md
+++ b/docs/RENDER_DEPLOYMENT.md
@@ -1,0 +1,35 @@
+# Render Deployment Guide
+
+This guide explains how to deploy Lego GPT to [Render](https://render.com) using the bundled `render.yaml` blueprint. The interface is English only.
+
+## Prerequisites
+
+- A Render account
+- Python 3.11 or newer
+- Node.js 20 with `pnpm`
+- A Redis instance (created automatically by the blueprint)
+
+## Steps
+
+1. Clone the repository and switch to the project root.
+2. Apply the blueprint:
+
+   ```bash
+   render blueprint apply render.yaml
+   ```
+
+3. Update any secrets or environment variables through the Render dashboard or via `envVarGroups`.
+4. The blueprint sets up two API services:
+   - `lego-gpt-api-green` (active)
+   - `lego-gpt-api-blue` (disabled for blue/green rollouts)
+5. A Redis instance and a static site for the front-end are provisioned automatically. The static site uses Node 20 during the build.
+6. Visit `/docs` on the API service URL to view the OpenAPI specification. Admin users can fetch `/metrics_prom` for Prometheus metrics.
+
+## Rolling Updates
+
+To perform a blue/green deployment:
+
+1. Enable the `lego-gpt-api-blue` service and wait for it to become healthy.
+2. Disable `lego-gpt-api-green` once the blue service is serving traffic successfully.
+3. Repeat the process for future updates, alternating between the two services.
+

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -10,4 +10,5 @@ nav:
   - Issue Triage: ISSUE_TRIAGE_GUIDE.md
   - LTS Policy: LTS_POLICY.md
   - Dependency Versions: DEPENDENCY_VERSIONS.md
+  - Render Deployment: RENDER_DEPLOYMENT.md
   - Backlog: PROJECT_BACKLOG.md

--- a/render.yaml
+++ b/render.yaml
@@ -65,6 +65,9 @@ services:
     buildCommand: |
       pnpm install --no-frozen-lockfile
       pnpm run build
+    envVars:
+      - key: NODE_VERSION
+        value: "20"
     staticPublishPath: dist
     branch: main
     autoDeploy: true


### PR DESCRIPTION
## Summary
- document Render deployment process
- link Render guide from README
- include Render doc in mkdocs
- specify Node 20 for static site in render.yaml

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_683a5e1aec0483278b170cda6e6938be