### PR TITLE
Update Render deployment docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [0.5.72] – 2025-05-31
+### Changed
+- Documentation tweaks for Render deployment.
+- Backend package version bumped to 0.5.72.
+
 ## [0.5.71] – 2025-05-31
 ### Added
 - FastAPI routes for `/generate`, `/detect_inventory`, `/metrics`,

--- a/README.md
+++ b/README.md
@@ -367,7 +367,8 @@ The configuration spins up a Redis instance, a Python web service running
 `uvicorn backend.api:app`, and a static site for the front-end build. Both API
 services target Python 3.11 and declare `/health` as the health check path.
 Update any environment variables in the Render dashboard or via
-`envVarGroups` as needed.
+`envVarGroups` as needed. Typical tweaks include setting `JWT_SECRET`, adjusting
+`RATE_LIMIT`, or pointing `LEGOGPT_MODEL` at a custom checkpoint.
 
 The blueprint defines two API services—`lego-gpt-api-green` and
 `lego-gpt-api-blue`. Only the green service is active by default. The blue

--- a/backend/__init__.py
+++ b/backend/__init__.py
@@ -22,7 +22,7 @@ except Exception:  # pragma: no cover - ignore if missing
 try:  # pragma: no cover - during editable installs
     __version__ = version("lego-gpt-backend")
 except PackageNotFoundError:  # pragma: no cover - fallback for tests
-    __version__ = "0.5.71"
+    __version__ = "0.5.72"
 
 PACKAGE_DIR = Path(__file__).parent
 REDIS_URL = os.getenv("REDIS_URL", "redis://localhost:6379/0")

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "lego-gpt-backend"
-version = "0.5.71"
+version = "0.5.72"
 requires-python = ">=3.11"
 dependencies = [
     "redis==5.0.0",

--- a/docs/RENDER_DEPLOYMENT.md
+++ b/docs/RENDER_DEPLOYMENT.md
@@ -18,7 +18,7 @@ This guide explains how to deploy Lego GPT to [Render](https://render.com) using
    render blueprint apply render.yaml
    ```
 
-3. Update any secrets or environment variables through the Render dashboard or via `envVarGroups`.
+3. Update any secrets or environment variables through the Render dashboard or via `envVarGroups`. Common options include setting `JWT_SECRET` for API authentication, tweaking `RATE_LIMIT`, and defining a custom `LEGOGPT_MODEL` path if you host a larger checkpoint.
 4. The blueprint sets up two API services:
    - `lego-gpt-api-green` (active)
    - `lego-gpt-api-blue` (disabled for blue/green rollouts)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "lego-gpt"
-version = "0.5.71"
+version = "0.5.72"
 requires-python = ">=3.11"
 
 [build-system]


### PR DESCRIPTION
## Summary
- clarify environment variable usage in Render docs
- mention env vars in README deployment section
- bump package version to 0.5.72

## Testing
- `pytest`
- `ruff check backend`

------
https://chatgpt.com/codex/tasks/task_e_683a60c613e883279582d17529494fe7