### PR TITLE
Update Render blueprint docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -368,7 +368,9 @@ The configuration spins up a Redis instance, a Python web service running
 services target Python 3.11 and declare `/health` as the health check path.
 Update any environment variables in the Render dashboard or via
 `envVarGroups` as needed. Typical tweaks include setting `JWT_SECRET`, adjusting
-`RATE_LIMIT`, or pointing `LEGOGPT_MODEL` at a custom checkpoint.
+`RATE_LIMIT`, or pointing `LEGOGPT_MODEL` at a custom checkpoint. The static
+site should define `VITE_API_URL` so the PWA knows which API instance to use
+(e.g. `https://lego-gpt-api-green.onrender.com`).
 
 The blueprint defines two API services—`lego-gpt-api-green` and
 `lego-gpt-api-blue`. Only the green service is active by default. The blue

--- a/docs/RENDER_DEPLOYMENT.md
+++ b/docs/RENDER_DEPLOYMENT.md
@@ -18,7 +18,7 @@ This guide explains how to deploy Lego GPT to [Render](https://render.com) using
    render blueprint apply render.yaml
    ```
 
-3. Update any secrets or environment variables through the Render dashboard or via `envVarGroups`. Common options include setting `JWT_SECRET` for API authentication, tweaking `RATE_LIMIT`, and defining a custom `LEGOGPT_MODEL` path if you host a larger checkpoint.
+3. Update any secrets or environment variables through the Render dashboard or via `envVarGroups`. Common options include setting `JWT_SECRET` for API authentication, tweaking `RATE_LIMIT`, defining `VITE_API_URL` for the front-end (e.g. `https://lego-gpt-api-green.onrender.com`), and supplying a custom `LEGOGPT_MODEL` path if you host a larger checkpoint.
 4. The blueprint sets up two API services:
    - `lego-gpt-api-green` (active)
    - `lego-gpt-api-blue` (disabled for blue/green rollouts)

--- a/render.yaml
+++ b/render.yaml
@@ -68,6 +68,8 @@ services:
     envVars:
       - key: NODE_VERSION
         value: "20"
+      - key: VITE_API_URL
+        value: "https://lego-gpt-api-green.onrender.com"
     staticPublishPath: dist
     branch: main
     autoDeploy: true


### PR DESCRIPTION
## Summary
- specify `VITE_API_URL` in the Render blueprint
- document the environment variable in README and Render guide

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683a6321ea8c83279c57bd68fef39a31