### PR TITLE
Update render deployment docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -370,7 +370,9 @@ Update any environment variables in the Render dashboard or via
 `envVarGroups` as needed. Typical tweaks include setting `JWT_SECRET`, adjusting
 `RATE_LIMIT`, or pointing `LEGOGPT_MODEL` at a custom checkpoint. The static
 site should define `VITE_API_URL` so the PWA knows which API instance to use
-(e.g. `https://lego-gpt-api-green.onrender.com`).
+(e.g. `https://lego-gpt-api-green.onrender.com`). If you switch to the blue
+service during a rollout, update the variable to
+`https://lego-gpt-api-blue.onrender.com`.
 
 The blueprint defines two API services—`lego-gpt-api-green` and
 `lego-gpt-api-blue`. Only the green service is active by default. The blue

--- a/docs/RENDER_DEPLOYMENT.md
+++ b/docs/RENDER_DEPLOYMENT.md
@@ -18,7 +18,7 @@ This guide explains how to deploy Lego GPT to [Render](https://render.com) using
    render blueprint apply render.yaml
    ```
 
-3. Update any secrets or environment variables through the Render dashboard or via `envVarGroups`. Common options include setting `JWT_SECRET` for API authentication, tweaking `RATE_LIMIT`, defining `VITE_API_URL` for the front-end (e.g. `https://lego-gpt-api-green.onrender.com`), and supplying a custom `LEGOGPT_MODEL` path if you host a larger checkpoint.
+3. Update any secrets or environment variables through the Render dashboard or via `envVarGroups`. Common options include setting `JWT_SECRET` for API authentication, tweaking `RATE_LIMIT`, defining `VITE_API_URL` for the front-end (e.g. `https://lego-gpt-api-green.onrender.com`), and supplying a custom `LEGOGPT_MODEL` path if you host a larger checkpoint. When switching to the blue instance, be sure to update `VITE_API_URL` to `https://lego-gpt-api-blue.onrender.com` so the PWA targets the correct API.
 4. The blueprint sets up two API services:
    - `lego-gpt-api-green` (active)
    - `lego-gpt-api-blue` (disabled for blue/green rollouts)


### PR DESCRIPTION
## Summary
- clarify that VITE_API_URL must switch when using blue/green rollout

## Testing
- `./scripts/run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_683a64e236b48327ba793d8f29b56164