### PR TITLE
Execute sprint plan step: Render rollout

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ real-life building via a built-in Three.js viewer.
 | 🆕 **Photo‑based brick inventory detection** – YOLOv8 detector + `/detect_inventory` API | Scan your loose bricks and generate builds you can actually build |
 | 📸 **Multiple inventory photos** | Combine several detected images into one project file |
 | 🛡️ **Static file handler sanitized** | Blocks path traversal in `/static` requests |
-| 🆕 **Console scripts** for API and workers (`lego-gpt-server`, `lego-gpt-worker`, `lego-detect-worker`) | Easier local development & Docker entrypoints; workers accept `--redis-url` and `--version` |
+| 🆕 **Console scripts** for API and workers (`lego-gpt-api`, `lego-gpt-worker`, `lego-detect-worker`) | Easier local development & Docker entrypoints; workers accept `--redis-url` and `--version` |
 | 🆕 **Command-line client** (`lego-gpt-cli`) | Test the API from your terminal or CI |
 | 🛠️ **Ruff linting** for backend code | Consistent style via `ruff check` locally and in CI |
 | 🌍 **CORS configuration** via `--cors-origins` | Allows custom `Access-Control-Allow-Origin` |
@@ -157,7 +157,7 @@ export LEGOGPT_MODEL=/path/to/checkpoint     # optional larger LegoGPT model
 # See ``docs/SCALABILITY_BENCHMARKING.md`` for load-testing guidance.
 # Alternatively set ``LEGOGPT_CONFIG`` or ``--config`` to load settings from a YAML file.
 # Generate a starter config with ``lego-gpt-config > config.yaml``.
-lego-gpt-server \
+lego-gpt-api \
   --host 0.0.0.0 \
   --port 8000 \
   --redis-url "$REDIS_URL" \

--- a/backend/Dockerfile.cpu
+++ b/backend/Dockerfile.cpu
@@ -29,4 +29,4 @@ RUN pip install --upgrade pip setuptools wheel --user && \
 
 WORKDIR /app/backend
 EXPOSE 8000
-CMD ["lego-gpt-server"]
+CMD ["lego-gpt-api"]

--- a/backend/Dockerfile.dev
+++ b/backend/Dockerfile.dev
@@ -16,4 +16,4 @@ RUN pip install --no-cache-dir --editable ./backend
 
 WORKDIR /app/backend
 EXPOSE 8000
-CMD ["lego-gpt-server"]
+CMD ["lego-gpt-api"]

--- a/backend/Dockerfile.gpu
+++ b/backend/Dockerfile.gpu
@@ -29,4 +29,4 @@ RUN pip3 install --upgrade pip setuptools wheel --user && \
 
 WORKDIR /app/backend
 EXPOSE 8000
-CMD ["lego-gpt-server"]
+CMD ["lego-gpt-api"]

--- a/backend/api.py
+++ b/backend/api.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 import json
 import os
 import time
+import argparse
 
 from redis import Redis
 from rq import Queue, Retry
@@ -22,6 +23,7 @@ from pydantic import BaseModel
 from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
 from fastapi.middleware.cors import CORSMiddleware
 from starlette.concurrency import run_in_threadpool
+import uvicorn
 
 from backend import (
     __version__,
@@ -263,4 +265,20 @@ async def history_route(auth: tuple[dict, str] = Depends(_auth)) -> dict:
     else:
         entries = []
     return {"history": entries}
+
+
+def main() -> None:
+    """Run the FastAPI server via uvicorn."""
+    parser = argparse.ArgumentParser(description="Run Lego GPT FastAPI server")
+    parser.add_argument("--host", default=os.getenv("HOST", "0.0.0.0"))
+    parser.add_argument("--port", type=int, default=int(os.getenv("PORT", "8000")))
+    parser.add_argument(
+        "--reload", action="store_true", help="Enable auto-reload for development"
+    )
+    args = parser.parse_args()
+    uvicorn.run("backend.api:app", host=args.host, port=args.port, reload=args.reload)
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry point
+    main()
 

--- a/backend/docker-compose.yml
+++ b/backend/docker-compose.yml
@@ -14,7 +14,7 @@ services:
       - .:/app/backend
     ports:
       - "8000:8000"
-    command: lego-gpt-server
+    command: lego-gpt-api
   worker:
     build:
       context: .

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -32,6 +32,7 @@ env = [
 
 [project.scripts]
 lego-gpt-server = "backend.gateway:main"
+lego-gpt-api = "backend.api:main"
 lego-gpt-worker = "backend.worker:main"
 lego-detect-worker = "detector.worker:main"
 lego-detect-train = "detector.train:main"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,7 +13,7 @@ services:
       - ./backend:/app/backend:delegated
     ports:
       - "8000:8000"
-    command: lego-gpt-server
+    command: lego-gpt-api
   worker:
     build:
       context: .

--- a/docs/PROJECT_BACKLOG.md
+++ b/docs/PROJECT_BACKLOG.md
@@ -25,7 +25,7 @@ The application is English-only. Multi-language user interfaces are out of scope
 | B-12 | **XS** | JWT auth unit tests                  | **Done** | encode/decode helpers |
 | B-13 | **XS** | Front-end lint step in CI            | **Done** | pnpm runs ESLint in workflow |
 | B-14 | **S** | YOLOv8 model auto-loader            | **Done** | `DETECTOR_MODEL` env var selects weights |
-| B-15 | **XS** | Console scripts for server/worker   | **Done** | `lego-gpt-server`, `lego-gpt-worker`, `lego-detect-worker` |
+| B-15 | **XS** | Console scripts for server/worker   | **Done** | `lego-gpt-api`, `lego-gpt-worker`, `lego-detect-worker` |
 | B-16 | **XS** | Ruff lint + CI step                 | **Done** | pyproject config + workflow |
 | B-17 | **XS** | Configurable CORS headers            | **Done** | `--cors-origins` CLI + tests |
 | B-18 | **S** | Customisable static URL prefix       | **Done** | `STATIC_URL_PREFIX` env var |

--- a/docs/SCALABILITY_BENCHMARKING.md
+++ b/docs/SCALABILITY_BENCHMARKING.md
@@ -7,7 +7,7 @@ This guide explains how to measure API throughput and tune your deployment.
 ## 1. Prerequisites
 
 * A running Redis instance and at least one `lego-gpt-worker`.
-* The API server started via `lego-gpt-server`.
+* The API server started via `lego-gpt-api`.
 * A valid JWT token for authentication.
 
 ## 2. Benchmark script


### PR DESCRIPTION
## Summary
- add `lego-gpt-api` script and CLI entrypoint
- update Dockerfiles and docker-compose to use the FastAPI server
- update docs to reference `lego-gpt-api` instead of `lego-gpt-server`
- note new script in project backlog

## Testing
- `python -m pytest -q`
- `ruff check backend detector`

------
https://chatgpt.com/codex/tasks/task_e_683a66f3fb708327a393a3a18b321e64